### PR TITLE
`Backends.Z3`: error handling

### DIFF
--- a/Z3/smtlib-backends-z3.cabal
+++ b/Z3/smtlib-backends-z3.cabal
@@ -33,7 +33,10 @@ test-suite test
   main-is: Main.hs
   ghc-options:         -threaded -Wall -Wunused-packages
   build-depends:       base >= 4.15,
+                       bytestring >= 0.10,
+                       smtlib-backends,
                        smtlib-backends-z3,
                        smtlib-backends-tests,
-                       tasty
+                       tasty,
+                       tasty-hunit >= 0.10
   default-language:    Haskell2010

--- a/Z3/src/SMTLIB/Backends/Z3.hs
+++ b/Z3/src/SMTLIB/Backends/Z3.hs
@@ -59,8 +59,8 @@ new = do
 
   {-
   We set the error handler to ignore errors. That way if an error happens it doesn't
-  cause the whole program to crash, and the error message if simply transmitted to
-  the Haskell layer inside the output of the eval_smtlib2_string function.
+  cause the whole program to crash, and the error message is simply transmitted to
+  the Haskell layer inside the output of the `send` method.
   -}
   ctx <-
     newForeignPtr ctxFinalizer

--- a/Z3/src/SMTLIB/Backends/Z3.hs
+++ b/Z3/src/SMTLIB/Backends/Z3.hs
@@ -56,12 +56,22 @@ new = do
         [C.funPtr| void free_context(Z3_context ctx) {
                  Z3_del_context(ctx);
                  } |]
+
+  {-
+  We set the error handler to ignore errors. That way if an error happens it doesn't
+  cause the whole program to crash, and the error message if simply transmitted to
+  the Haskell layer inside the output of the eval_smtlib2_string function.
+  -}
   ctx <-
     newForeignPtr ctxFinalizer
       =<< [CU.block| Z3_context {
                  Z3_config cfg = Z3_mk_config();
                  Z3_context ctx = Z3_mk_context(cfg);
                  Z3_del_config(cfg);
+
+                 void ignore_error(Z3_context c, Z3_error_code e) {}
+                 Z3_set_error_handler(ctx, ignore_error);
+
                  return ctx;
                  } |]
   return $ Z3 ctx

--- a/Z3/tests/Main.hs
+++ b/Z3/tests/Main.hs
@@ -1,15 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import SMTLIB.Backends
 import SMTLIB.Backends.Tests
 import qualified SMTLIB.Backends.Z3 as Z3
 import Test.Tasty
+import Test.Tasty.HUnit
 
 main :: IO ()
 main = do
   defaultMain $
     testGroup "Tests" $
-      [ testBackend "Z3" validSources noLogging $ \todo ->
-          Z3.with $ todo . Z3.toBackend
+      [ testBackend "Examples" validSources noLogging z3,
+        testBackend "Error handling" failingSources noLogging z3
       ]
   where
+    z3 todo = Z3.with $ todo . Z3.toBackend
     noLogging = const $ return ()
-    -- validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
-    validSources = sources
+    validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
+    failingSources =
+      [ Source "invalid command" $ \solver -> do
+          result <- command solver "this is not a valid command!!!"
+          assertBool ("Expecting error message, got: " ++ LBS.unpack result) $ "(error" `LBS.isPrefixOf` result
+      ]

--- a/Z3/tests/Main.hs
+++ b/Z3/tests/Main.hs
@@ -11,4 +11,5 @@ main = do
       ]
   where
     noLogging = const $ return ()
-    validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
+    -- validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
+    validSources = sources


### PR DESCRIPTION
This PR fixes #2 . It sets the error handler of the underlying Z3 context to do nothing, ensuring an error never causes the program to crash and the corresponding error message is rather transmitted to the Haskell layer as the output of the backend's `send` method.