### PR TITLE
improve the logging interface

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,8 @@ jobs:
       with:
         extra_nix_config: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - name: Update cabal
+      run: nix develop --accept-flake-config --command cabal update
     - name: Processes test
       run: nix develop --accept-flake-config --command cabal test
     - name: Z3 backend test

--- a/Z3/tests/Main.hs
+++ b/Z3/tests/Main.hs
@@ -16,7 +16,7 @@ main = do
       ]
   where
     z3 todo = Z3.with $ todo . Z3.toBackend
-    noLogging = const $ return ()
+    noLogging = \_ _ -> return ()
     validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
     failingSources =
       [ Source "invalid command" $ \solver -> do

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -18,6 +18,7 @@ library
   build-depends:       base >=4.8 && <10,
                        async,
                        bytestring >= 0.10,
+                       text >= 2.0,
                        typed-process 
   default-language:    Haskell2010
 
@@ -29,8 +30,8 @@ test-suite test
                        SMTLIB.Backends.Tests.Sources
   ghc-options:         -threaded -Wall -Wunused-packages
   build-depends:       base >= 4.15,
-                       bytestring >= 0.10,
                        smtlib-backends,
+                       text >= 1.2,
                        tasty,
                        tasty-hunit
   default-language:    Haskell2010

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -18,6 +18,7 @@ library
   build-depends:       base >=4.8 && <10,
                        async,
                        bytestring >= 0.10,
+                       data-default,
                        typed-process 
   default-language:    Haskell2010
 
@@ -30,6 +31,7 @@ test-suite test
   ghc-options:         -threaded -Wall -Wunused-packages
   build-depends:       base >= 4.15,
                        bytestring >= 0.10,
+                       data-default,
                        smtlib-backends,
                        tasty,
                        tasty-hunit

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -18,7 +18,6 @@ library
   build-depends:       base >=4.8 && <10,
                        async,
                        bytestring >= 0.10,
-                       text >= 2.0,
                        typed-process 
   default-language:    Haskell2010
 
@@ -30,8 +29,8 @@ test-suite test
                        SMTLIB.Backends.Tests.Sources
   ghc-options:         -threaded -Wall -Wunused-packages
   build-depends:       base >= 4.15,
+                       bytestring >= 0.10,
                        smtlib-backends,
-                       text >= 1.2,
                        tasty,
                        tasty-hunit
   default-language:    Haskell2010

--- a/src/SMTLIB/Backends.hs
+++ b/src/SMTLIB/Backends.hs
@@ -78,7 +78,8 @@ initSolver ::
   -- | whether to enable lazy mode (see 'Solver' for the meaning of this flag)
   Bool ->
   -- | function for logging the solver's activity;
-  -- it should manually jump lines if needed
+  -- if you want line breaks between each log message, you need to implement
+  -- it yourself, e.g use @`LBS.putStr` . (<> "\n")@.
   (LBS.ByteString -> IO ()) ->
   IO Solver
 initSolver solverBackend lazy logger = do

--- a/src/SMTLIB/Backends.hs
+++ b/src/SMTLIB/Backends.hs
@@ -79,8 +79,9 @@ initSolver ::
   Backend ->
   -- | whether to enable lazy mode (see 'Solver' for the meaning of this flag)
   Bool ->
-  -- | function for logging the solver's activity
-  (Builder -> IO ()) ->
+  -- | function for logging the solver's activity;
+  -- it should manually jump lines if needed
+  (Text -> IO ()) ->
   IO Solver
 initSolver solverBackend lazy logger = do
   solverQueue <-

--- a/src/SMTLIB/Backends.hs
+++ b/src/SMTLIB/Backends.hs
@@ -7,8 +7,6 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Char (isSpace)
 import Data.IORef (IORef, atomicModifyIORef, newIORef)
 import Data.List (intersperse)
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8Lenient)
 import Prelude hiding (log)
 
 -- | The type of solver backends. SMTLib2 commands are sent to a backend which
@@ -81,7 +79,7 @@ initSolver ::
   Bool ->
   -- | function for logging the solver's activity;
   -- it should manually jump lines if needed
-  (Text -> IO ()) ->
+  (LBS.ByteString -> IO ()) ->
   IO Solver
 initSolver solverBackend lazy logger = do
   solverQueue <-
@@ -90,7 +88,7 @@ initSolver solverBackend lazy logger = do
         ref <- newIORef mempty
         return $ Just ref
       else return Nothing
-  let solver = Solver solverBackend solverQueue $ logger . decodeUtf8Lenient . LBS.toStrict
+  let solver = Solver solverBackend solverQueue logger
   if lazy
     then return ()
     else -- this should not be enabled when the queue is used, as it messes with parsing

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -9,6 +9,7 @@ module SMTLIB.Backends.Process
   ( Config (..),
     Handle,
     new,
+    newNoLogging,
     wait,
     close,
     with,
@@ -97,6 +98,11 @@ new config logText = do
               logger $ BS.pack $ show (ex :: X.IOException)
           )
     logger = logText . decodeUtf8Lenient
+
+-- | Run a solver as a process. See `new`.
+-- Failures relative to terminating the process are ignored.
+newNoLogging :: Config -> IO Handle
+newNoLogging config = new config $ const $ return ()
 
 -- | Wait for the process to exit and cleanup its resources.
 wait :: Handle -> IO ExitCode

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -27,8 +27,7 @@ import Data.ByteString.Builder
     toLazyByteString,
   )
 import qualified Data.ByteString.Char8 as BS
-import Data.Text (Text)
-import Data.Text.Encoding (decodeUtf8Lenient)
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import SMTLIB.Backends (Backend (..))
 import System.Exit (ExitCode)
 import qualified System.IO as IO
@@ -67,9 +66,9 @@ new ::
   -- | The solver process' configuration.
   Config ->
   -- | A function for logging the solver's creation, errors and termination.
-  (Text -> IO ()) ->
+  (LBS.ByteString -> IO ()) ->
   IO Handle
-new config logText = do
+new config logLazy = do
   solverProcess <-
     startProcess $
       setStdin createLoggedPipe $
@@ -97,7 +96,7 @@ new config logText = do
             IO.hClose h `X.catch` \ex ->
               logger $ BS.pack $ show (ex :: X.IOException)
           )
-    logger = logText . decodeUtf8Lenient
+    logger = logLazy . LBS.fromStrict
 
 -- | Run a solver as a process. See `new`.
 -- Failures relative to terminating the process are ignored.
@@ -121,7 +120,7 @@ with ::
   -- | The solver process' configuration.
   Config ->
   -- | A function for logging the solver's creation, errors and termination.
-  (Text -> IO ()) ->
+  (LBS.ByteString -> IO ()) ->
   -- | The computation to run with the solver process
   (Handle -> IO a) ->
   IO a

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -61,6 +61,7 @@ data Handle = Handle
   }
 
 -- | Run a solver as a process.
+-- Failures relative to terminating the process are logged and discarded.
 new ::
   -- | The solver process' configuration.
   Config ->
@@ -110,7 +111,14 @@ close handle = do
   stopProcess $ process handle
 
 -- | Create a solver process, use it to make a computation and stop it.
-with :: Config -> (Text -> IO ()) -> (Handle -> IO a) -> IO a
+with ::
+  -- | The solver process' configuration.
+  Config ->
+  -- | A function for logging the solver's creation, errors and termination.
+  (Text -> IO ()) ->
+  -- | The computation to run with the solver process
+  (Handle -> IO a) ->
+  IO a
 with config logger = X.bracket (new config logger) close
 
 infixr 5 :<

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -55,8 +55,8 @@ data Config = Config
     logger :: LBS.ByteString -> IO ()
   }
 
+-- | By default, use Z3 as an external process and ignore log messages.
 instance Default Config where
-  -- By default, use Z3 as an external process and ignore log messages.
   def = Config "z3" ["-in"] $ const $ return ()
 
 data Handle = Handle

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -87,7 +87,7 @@ new config = do
       forever
         ( do
             errs <- BS.hGetLine $ getStderr solverProcess
-            logger' $ "[stderr] " <> errs
+            logger' $ errs
         )
         `X.catch` \X.SomeException {} ->
           return ()

--- a/src/SMTLIB/Backends/Process.hs
+++ b/src/SMTLIB/Backends/Process.hs
@@ -52,6 +52,8 @@ data Config = Config
     -- | Arguments to pass to the solver's command.
     args :: [String],
     -- | A function for logging the solver process' creation, errors and termination.
+    -- If you want line breaks between each log message, you need to implement
+    -- it yourself, e.g use @`LBS.putStr` . (<> "\n")@.
     logger :: LBS.ByteString -> IO ()
   }
 

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -16,8 +16,8 @@ library
   exposed-modules:     SMTLIB.Backends.Tests
   other-modules:       SMTLIB.Backends.Tests.Sources
   build-depends:       base >= 4.15,
+                       bytestring >= 0.10,
                        smtlib-backends,
-                       text >= 1.2,
                        tasty,
                        tasty-hunit
   default-language: Haskell2010

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -16,8 +16,8 @@ library
   exposed-modules:     SMTLIB.Backends.Tests
   other-modules:       SMTLIB.Backends.Tests.Sources
   build-depends:       base >= 4.15,
-                       bytestring >= 0.10,
                        smtlib-backends,
+                       text >= 1.2,
                        tasty,
                        tasty-hunit
   default-language: Haskell2010

--- a/tests/src/Main.hs
+++ b/tests/src/Main.hs
@@ -12,4 +12,4 @@ main = do
           Process.with def $ todo . Process.toBackend
       ]
   where
-    noLogging = const $ return ()
+    noLogging = \_ _ -> return ()

--- a/tests/src/Main.hs
+++ b/tests/src/Main.hs
@@ -1,3 +1,4 @@
+import Data.Default (def)
 import qualified SMTLIB.Backends.Process as Process
 import SMTLIB.Backends.Tests (sources, testBackend)
 import Test.Tasty
@@ -8,7 +9,7 @@ main = do
     testGroup
       "backends"
       [ testBackend "process" sources noLogging $ \todo ->
-          Process.with (Process.Config "z3" ["-in"]) noLogging $ todo . Process.toBackend
+          Process.with def $ todo . Process.toBackend
       ]
   where
     noLogging = const $ return ()

--- a/tests/src/SMTLIB/Backends/Tests.hs
+++ b/tests/src/SMTLIB/Backends/Tests.hs
@@ -6,7 +6,7 @@ module SMTLIB.Backends.Tests
   )
 where
 
-import Data.ByteString.Builder (Builder)
+import Data.Text (Text)
 import SMTLIB.Backends (Backend, initSolver)
 import qualified SMTLIB.Backends.Tests.Sources as Src
 import Test.Tasty
@@ -19,7 +19,7 @@ testBackend ::
   -- | A list of examples on which to run the backend.
   [Src.Source] ->
   -- | A function for logging the solver's activity.
-  (Builder -> IO ()) ->
+  (Text -> IO ()) ->
   -- | A function that should create a backend, run a given
   -- computation and release the backend's resources.
   ((Backend -> Assertion) -> Assertion) ->

--- a/tests/src/SMTLIB/Backends/Tests.hs
+++ b/tests/src/SMTLIB/Backends/Tests.hs
@@ -6,7 +6,7 @@ module SMTLIB.Backends.Tests
   )
 where
 
-import Data.Text (Text)
+import Data.ByteString.Lazy.Char8 as LBS
 import SMTLIB.Backends (Backend, initSolver)
 import qualified SMTLIB.Backends.Tests.Sources as Src
 import Test.Tasty
@@ -19,7 +19,7 @@ testBackend ::
   -- | A list of examples on which to run the backend.
   [Src.Source] ->
   -- | A function for logging the solver's activity.
-  (Text -> IO ()) ->
+  (LBS.ByteString -> IO ()) ->
   -- | A function that should create a backend, run a given
   -- computation and release the backend's resources.
   ((Backend -> Assertion) -> Assertion) ->

--- a/tests/src/SMTLIB/Backends/Tests.hs
+++ b/tests/src/SMTLIB/Backends/Tests.hs
@@ -7,7 +7,7 @@ module SMTLIB.Backends.Tests
 where
 
 import Data.ByteString.Lazy.Char8 as LBS
-import SMTLIB.Backends (Backend, initSolver)
+import SMTLIB.Backends (Backend, LogType, initSolver)
 import qualified SMTLIB.Backends.Tests.Sources as Src
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -19,7 +19,7 @@ testBackend ::
   -- | A list of examples on which to run the backend.
   [Src.Source] ->
   -- | A function for logging the solver's activity.
-  (LBS.ByteString -> IO ()) ->
+  (LogType -> LBS.ByteString -> IO ()) ->
   -- | A function that should create a backend, run a given
   -- computation and release the backend's resources.
   ((Backend -> Assertion) -> Assertion) ->


### PR DESCRIPTION
An alternative to #6:
- logging functions all take `Text` as input
- add a `Process.newNoLogging` function (it turns out I had already added a `initSolverNoLogging` function before - at least I'm consistent with myself :sunglasses: )
- add and improve some comments