### PR TITLE
Prepare metadata for Hackage release

### DIFF
--- a/Z3/smtlib-backends-z3.cabal
+++ b/Z3/smtlib-backends-z3.cabal
@@ -7,6 +7,7 @@ license-file:        LICENSE
 author:              Quentin Aristote
 maintainer:          quentin.aristote@tweag.io
 build-type:          Simple
+category:            SMT
 cabal-version:       >=1.10
 
 library

--- a/Z3/smtlib-backends-z3.cabal
+++ b/Z3/smtlib-backends-z3.cabal
@@ -14,7 +14,7 @@ library
   hs-source-dirs:      src
   ghc-options:         -Wall -Wunused-packages
   exposed-modules:     SMTLIB.Backends.Z3
-  build-depends:       base >= 4.15,
+  build-depends:       base >= 4.15 && <= 4.17,
                        smtlib-backends,
                        containers >= 0.6,
                        bytestring >= 0.10,

--- a/Z3/smtlib-backends-z3.cabal
+++ b/Z3/smtlib-backends-z3.cabal
@@ -1,53 +1,63 @@
-name:                smtlib-backends-z3
-version:             0.1
-synopsis:            An SMT-LIB backend implemented using Z3's C API.
-description:         This library implements an SMT-LIB backend (in the sense of the smtlib-backends package) using inlined calls to Z3's C API. It is thus in particular much faster than the standard backends relying on running solvers as external processes.
-license:             MIT
-license-file:        LICENSE
-author:              Quentin Aristote
-maintainer:          quentin.aristote@tweag.io
-build-type:          Simple
-category:            SMT
-cabal-version:       >=1.10
+name:          smtlib-backends-z3
+version:       0.1
+synopsis:      An SMT-LIB backend implemented using Z3's C API.
+description:
+  This library implements an SMT-LIB backend (in the sense of the smtlib-backends package) using inlined calls to Z3's C API. It is thus in particular much faster than the standard backends relying on running solvers as external processes.
+
+license:       MIT
+license-file:  LICENSE
+author:        Quentin Aristote
+maintainer:    quentin.aristote@tweag.io
+build-type:    Simple
+category:      SMT
+cabal-version: >=1.10
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
-  subdir: Z3
+  subdir:   Z3
+
 source-repository this
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag: 0.1
-  subdir: Z3
+  tag:      0.1
+  subdir:   Z3
 
 library
-  hs-source-dirs:      src
-  ghc-options:         -Wall -Wunused-packages
-  exposed-modules:     SMTLIB.Backends.Z3
-  build-depends:       base >= 4.15 && <= 4.17,
-                       smtlib-backends,
-                       containers >= 0.6,
-                       bytestring >= 0.10,
-                       inline-c
+  hs-source-dirs:   src
+  ghc-options:      -Wall -Wunused-packages
+  exposed-modules:  SMTLIB.Backends.Z3
+  build-depends:
+      base             >=4.15 && <4.17.0
+    , bytestring       >=0.10
+    , containers       >=0.6
+    , inline-c
+    , smtlib-backends
+
   -- inspired from haskell-z3
-  if os(darwin) || os(windows)
-    extra-libraries:
-        z3
+  if (os(osx) || os(windows))
+    extra-libraries: z3
+
   else
     extra-libraries:
-        gomp z3 gomp
+      gomp
+      z3
+      gomp
+
   default-language: Haskell2010
 
 test-suite test
-  type: exitcode-stdio-1.0
-  hs-source-dirs:      tests
-  main-is: Main.hs
-  ghc-options:         -threaded -Wall -Wunused-packages
-  build-depends:       base >= 4.15,
-                       bytestring >= 0.10,
-                       smtlib-backends,
-                       smtlib-backends-z3,
-                       smtlib-backends-tests,
-                       tasty,
-                       tasty-hunit >= 0.10
-  default-language:    Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  main-is:          Main.hs
+  ghc-options:      -threaded -Wall -Wunused-packages
+  build-depends:
+      base                   >=4.15
+    , bytestring             >=0.10
+    , smtlib-backends
+    , smtlib-backends-tests
+    , smtlib-backends-z3
+    , tasty
+    , tasty-hunit            >=0.10
+
+  default-language: Haskell2010

--- a/Z3/smtlib-backends-z3.cabal
+++ b/Z3/smtlib-backends-z3.cabal
@@ -10,6 +10,16 @@ build-type:          Simple
 category:            SMT
 cabal-version:       >=1.10
 
+source-repository head
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+  subdir: Z3
+source-repository this
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+  tag: 0.1
+  subdir: Z3
+
 library
   hs-source-dirs:      src
   ghc-options:         -Wall -Wunused-packages

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
                 cabal-install
                 hlint
                 haskell-language-server
+                cabal-fmt
               ])
               ++ [pkgs.z3];
 

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -1,45 +1,58 @@
-name:                smtlib-backends
-version:             0.1
-synopsis:            Low-level functions for SMT-LIB-based interaction with SMT solvers. 
-description:         This library provides an extensible interface for interacting with SMT solvers using SMT-LIB. It has built-in support for running solvers as external processes, and the smtlib-backends-z3 package provides a backend that uses inlined calls to Z3's C API.
-license:             MIT
-license-file:        LICENSE
-author:              Quentin Aristote
-maintainer:          quentin.aristote@tweag.io
-build-type:          Simple
-category:            SMT
-cabal-version:       >=1.10
+name:          smtlib-backends
+version:       0.1
+synopsis:
+  Low-level functions for SMT-LIB-based interaction with SMT solvers. 
+
+description:
+  This library provides an extensible interface for interacting with SMT solvers using SMT-LIB. It has built-in support for running solvers as external processes, and the smtlib-backends-z3 package provides a backend that uses inlined calls to Z3's C API.
+
+license:       MIT
+license-file:  LICENSE
+author:        Quentin Aristote
+maintainer:    quentin.aristote@tweag.io
+build-type:    Simple
+category:      SMT
+cabal-version: >=1.10
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
+
 source-repository this
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag: 0.1
+  tag:      0.1
 
 library
-  hs-source-dirs:      src
-  ghc-options:         -Wall -Wunused-packages
-  exposed-modules:     SMTLIB.Backends
-                       SMTLIB.Backends.Process
-  other-extensions:    Safe
-  build-depends:       base >= 4.15 && <= 4.17,
-                       async,
-                       bytestring >= 0.10,
-                       typed-process 
-  default-language:    Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall -Wunused-packages
+  exposed-modules:
+    SMTLIB.Backends
+    SMTLIB.Backends.Process
+
+  other-extensions: Safe
+  build-depends:
+      async
+    , base           >=4.15 && <4.17.0
+    , bytestring     >=0.10
+    , typed-process
+
+  default-language: Haskell2010
 
 test-suite test
-  type: exitcode-stdio-1.0
-  hs-source-dirs:      tests/src
-  main-is:             Main.hs
-  other-modules:       SMTLIB.Backends.Tests
-                       SMTLIB.Backends.Tests.Sources
-  ghc-options:         -threaded -Wall -Wunused-packages
-  build-depends:       base >= 4.15 && <= 4.17,
-                       bytestring >= 0.10,
-                       smtlib-backends,
-                       tasty,
-                       tasty-hunit
-  default-language:    Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests/src
+  main-is:          Main.hs
+  other-modules:
+    SMTLIB.Backends.Tests
+    SMTLIB.Backends.Tests.Sources
+
+  ghc-options:      -threaded -Wall -Wunused-packages
+  build-depends:
+      base             >=4.15 && <4.17.0
+    , bytestring       >=0.10
+    , smtlib-backends
+    , tasty
+    , tasty-hunit
+
+  default-language: Haskell2010

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -1,7 +1,7 @@
 name:                smtlib-backends
 version:             0.1
 synopsis:            Low-level functions for SMT-LIB-based interaction with SMT solvers. 
-description:         This library provides an extensible interface for interacting with SMT solvers using SMT-LIB. It has built-in support for running solvers as external processes, and the smtlib-backends-z3 package provides a backend that uses inlined call to Z3's C API.
+description:         This library provides an extensible interface for interacting with SMT solvers using SMT-LIB. It has built-in support for running solvers as external processes, and the smtlib-backends-z3 package provides a backend that uses inlined calls to Z3's C API.
 license:             MIT
 license-file:        LICENSE
 author:              Quentin Aristote

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -1,12 +1,13 @@
 name:                smtlib-backends
 version:             0.1
-synopsis:            A library providing low-level functions for SMT-LIB-based interaction with SMT solvers. 
+synopsis:            Low-level functions for SMT-LIB-based interaction with SMT solvers. 
 description:         This library provides an extensible interface for interacting with SMT solvers using SMT-LIB. It has built-in support for running solvers as external processes, and the smtlib-backends-z3 package provides a backend that uses inlined call to Z3's C API.
 license:             MIT
 license-file:        LICENSE
 author:              Quentin Aristote
 maintainer:          quentin.aristote@tweag.io
 build-type:          Simple
+category:            SMT
 cabal-version:       >=1.10
 
 library

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -16,7 +16,7 @@ library
   exposed-modules:     SMTLIB.Backends
                        SMTLIB.Backends.Process
   other-extensions:    Safe
-  build-depends:       base >=4.8 && <10,
+  build-depends:       base >= 4.15 && <= 4.17,
                        async,
                        bytestring >= 0.10,
                        typed-process 
@@ -29,7 +29,7 @@ test-suite test
   other-modules:       SMTLIB.Backends.Tests
                        SMTLIB.Backends.Tests.Sources
   ghc-options:         -threaded -Wall -Wunused-packages
-  build-depends:       base >= 4.15,
+  build-depends:       base >= 4.15 && <= 4.17,
                        bytestring >= 0.10,
                        smtlib-backends,
                        tasty,

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -10,6 +10,14 @@ build-type:          Simple
 category:            SMT
 cabal-version:       >=1.10
 
+source-repository head
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+source-repository this
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+  tag: 0.1
+
 library
   hs-source-dirs:      src
   ghc-options:         -Wall -Wunused-packages

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -7,6 +7,7 @@ license-file:        LICENSE
 author:              Quentin Aristote
 maintainer:          quentin.aristote@tweag.io
 build-type:          Simple
+category:            SMT, Testing
 cabal-version:       >=1.10
 
 library

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -10,6 +10,16 @@ build-type:          Simple
 category:            SMT, Testing
 cabal-version:       >=1.10
 
+source-repository head
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+  subdir: tests
+source-repository this
+  type: git
+  location: https://github.com/tweag/smtlib-backends
+  tag: 0.1
+  subdir: tests
+
 library
   ghc-options:         -Wall -Wunused-packages
   hs-source-dirs:      src

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -23,7 +23,6 @@ source-repository this
 library
   ghc-options:         -Wall -Wunused-packages
   hs-source-dirs:      src
-  main-is:             Main.hs
   exposed-modules:     SMTLIB.Backends.Tests
   other-modules:       SMTLIB.Backends.Tests.Sources
   build-depends:       base >= 4.15 && <= 4.17,

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -1,33 +1,38 @@
-name:                smtlib-backends-tests
-version:             0.1
-synopsis:            Testing SMT-LIB backends.
-description:         This library provides common functions and values used for testing SMT-LIB backends, as provided by the smtlib-backends library.
-license:             MIT
-license-file:        LICENSE
-author:              Quentin Aristote
-maintainer:          quentin.aristote@tweag.io
-build-type:          Simple
-category:            SMT, Testing
-cabal-version:       >=1.10
+name:          smtlib-backends-tests
+version:       0.1
+synopsis:      Testing SMT-LIB backends.
+description:
+  This library provides common functions and values used for testing SMT-LIB backends, as provided by the smtlib-backends library.
+
+license:       MIT
+license-file:  LICENSE
+author:        Quentin Aristote
+maintainer:    quentin.aristote@tweag.io
+build-type:    Simple
+category:      SMT, Testing
+cabal-version: >=1.10
 
 source-repository head
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
-  subdir: tests
+  subdir:   tests
+
 source-repository this
-  type: git
+  type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag: 0.1
-  subdir: tests
+  tag:      0.1
+  subdir:   tests
 
 library
-  ghc-options:         -Wall -Wunused-packages
-  hs-source-dirs:      src
-  exposed-modules:     SMTLIB.Backends.Tests
-  other-modules:       SMTLIB.Backends.Tests.Sources
-  build-depends:       base >= 4.15 && <= 4.17,
-                       bytestring >= 0.10,
-                       smtlib-backends,
-                       tasty,
-                       tasty-hunit
+  ghc-options:      -Wall -Wunused-packages
+  hs-source-dirs:   src
+  exposed-modules:  SMTLIB.Backends.Tests
+  other-modules:    SMTLIB.Backends.Tests.Sources
+  build-depends:
+      base             >=4.15 && <4.17.0
+    , bytestring       >=0.10
+    , smtlib-backends
+    , tasty
+    , tasty-hunit
+
   default-language: Haskell2010

--- a/tests/smtlib-backends-tests.cabal
+++ b/tests/smtlib-backends-tests.cabal
@@ -16,7 +16,7 @@ library
   main-is:             Main.hs
   exposed-modules:     SMTLIB.Backends.Tests
   other-modules:       SMTLIB.Backends.Tests.Sources
-  build-depends:       base >= 4.15,
+  build-depends:       base >= 4.15 && <= 4.17,
                        bytestring >= 0.10,
                        smtlib-backends,
                        tasty,


### PR DESCRIPTION
I consider the current version of the master branch to be good enough to be published on Hackage and integrated inside Pirouette. This PR thus makes the Cabal project Hackage-compliant.

- Is anything else needed before publishing this as version `0.1` on Hackage ?
- Is it a good idea to run `cabal check` as a CI action to ensure the project is always Hackage-compliant ?
- I only used the `SMT` category as the library has a very specific goal. Should other tags be added ?