### PR TITLE
`README`: wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ We currently provide two different backends: a classic backend implemented by
 running solvers as external processes, and a faster backend, available in the
 `smtlib-backends-z3` package, implemented using Z3 as a library.
 
-In addition, the API allows to queue commands to be sent to the logger
-when a response is demanded, which we have observed to reduce the communication
+In addition, the API allows to queue commands which are then to be sent to the logger
+only when a response is demanded, as we have observed this to reduce the communication
 overhead. See the documentation of
 [SMTLIB.Backends.Solver](src/SMTLIB/Backends.hs) for the details.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We currently provide two different backends: a classic backend implemented by
 running solvers as external processes, and a faster backend, available in the
 `smtlib-backends-z3` package, implemented using Z3 as a library.
 
-In addition, the API allows to queue commands which are then to be sent to the logger
+In addition, the API allows to queue commands which are sent to the logger
 only when a response is demanded, as we have observed this to reduce the communication
 overhead. See the documentation of
 [SMTLIB.Backends.Solver](src/SMTLIB/Backends.hs) for the details.


### PR DESCRIPTION
I reread the `README` and didn't understand this

> In addition, the API allows to queue commands to be sent to the logger when a response is demanded, which we have observed to reduce the communication overhead.

I proposed a change in this PR, but I don't know if that's what you had in mind @facundominguez.