### PR TITLE
cabal: bump dependency version upper bounds

### DIFF
--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -34,7 +34,7 @@ library
       async            >=2.2.4   && <2.3
     , base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
-    , data-default     ==0.7.1
+    , data-default     >=0.7.1   && <0.8 
     , smtlib-backends  >=0.2     && <0.3
     , typed-process    >=0.2.10  && <0.3
 

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -34,7 +34,7 @@ library
       async            >=2.2.4   && <2.3
     , base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
-    , data-default     >=0.7.1   && <0.8 
+    , data-default     >=0.7.1   && <0.8
     , smtlib-backends  >=0.2     && <0.3
     , typed-process    >=0.2.10  && <0.3
 

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -32,9 +32,9 @@ library
   other-extensions: Safe
   build-depends:
       async            >=2.2.4   && <2.3
-    , base             >=4.14    && <4.17.0
-    , bytestring       >=0.10.12 && <0.11
-    , data-default     >=0.7.1   && <0.8
+    , base             >=4.14    && <4.18
+    , bytestring       >=0.10.12 && <0.12
+    , data-default     ==0.7.1
     , smtlib-backends  >=0.2     && <0.3
     , typed-process    >=0.2.10  && <0.3
 

--- a/smtlib-backends-tests/smtlib-backends-tests.cabal
+++ b/smtlib-backends-tests/smtlib-backends-tests.cabal
@@ -31,7 +31,7 @@ library
   exposed-modules:  SMTLIB.Backends.Tests
   other-modules:    SMTLIB.Backends.Tests.Sources
   build-depends:
-      base             >=4.14   && <4.17.0
+      base             >=4.14   && <4.18
     , smtlib-backends  >=0.2    && <0.3
     , tasty            >=1.4.2  && <1.5
     , tasty-hunit      >=0.10.0 && <0.11

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -32,8 +32,8 @@ library
   ghc-options:      -Wall -Wunused-packages
   exposed-modules:  SMTLIB.Backends.Z3
   build-depends:
-      base             >=4.14    && <4.17.0
-    , bytestring       >=0.10.12 && <0.11
+      base             >=4.14    && <4.18
+    , bytestring       >=0.10.12 && <0.12
     , containers       >=0.6.4   && <0.7
     , inline-c         >=0.9.1   && <0.10
     , smtlib-backends  >=0.2     && <0.3

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -33,7 +33,7 @@ library
   exposed-modules:  SMTLIB.Backends
   other-extensions: Safe
   build-depends:
-      base        >=4.14    && <4.17.0
-    , bytestring  >=0.10.12 && <0.11
+      base        >=4.14    && <4.18
+    , bytestring  >=0.10.12 && <0.12
 
   default-language: Haskell2010


### PR DESCRIPTION
See #4:

> Currently the libraries depend on bytestring>=0.10.12 && <0.11, yet they are perfectly compatible with, say, bytestring==0.11.3. This restriction thus introduces useless conflicts.