### PR TITLE
Update formatting

### DIFF
--- a/smtlib-backends-tests/src/SMTLIB/Backends/Tests.hs
+++ b/smtlib-backends-tests/src/SMTLIB/Backends/Tests.hs
@@ -26,19 +26,19 @@ testBackend ::
 testBackend name sources with =
   testGroup name $ do
     lazyMode <- [False, True]
-    return $
-      testGroup
+    return
+      $ testGroup
         ( if lazyMode
             then "lazy"
             else "eager"
         )
-        $ do
-          source <- sources
-          return $
-            testCase (Src.name source) $
-              with $ \backend -> do
-                solver <- initSolver backend lazyMode
-                Src.run source solver
-                -- ensure the sources consisting only of queued commands also run
-                _ <- command solver "(get-info :name)"
-                return ()
+      $ do
+        source <- sources
+        return $
+          testCase (Src.name source) $
+            with $ \backend -> do
+              solver <- initSolver backend lazyMode
+              Src.run source solver
+              -- ensure the sources consisting only of queued commands also run
+              _ <- command solver "(get-info :name)"
+              return ()


### PR DESCRIPTION
It seems `ormolu` has been updated and the files are no longer correctly formatted: see https://github.com/tweag/smtlib-backends/actions/runs/3828909877/jobs/6515018389. This PR fixes this.