### PR TITLE
`Process` backend: add a function for sending `(exit)`

### DIFF
--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v0.3-alpha
 - make test-suite compatible with `smtlib-backends-0.3`
 - rename `Process.close` to `Process.kill`
-- rename `Process.wait` to `Process.close`
+- rename `Process.wait` to `Process.close` and improve it
   - ensure the process gets killed even if an error is caught
   - send an `(exit)` command before waiting for the process to exit
   - this means `Process.with` now closes the process with this new version of

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -8,6 +8,8 @@
     `Process.close`, hence gracefully
 - add a `Process.write` function for writing commands without reading the
   solver's response
+- add a test checking that we can pile up procedures for exiting a process
+  safely
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -1,5 +1,13 @@
 # v0.3-alpha
 - make test-suite compatible with `smtlib-backends-0.3`
+- rename `Process.close` to `Process.kill`
+- rename `Process.wait` to `Process.close`
+  - ensure the process gets killed even if an error is caught
+  - send an `(exit)` command before waiting for the process to exit
+  - this means `Process.with` now closes the process with this new version of
+    `Process.close`, hence gracefully
+- add a `Process.write` function for writing commands without reading the
+  solver's response
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/tests/Examples.hs
+++ b/smtlib-backends-process/tests/Examples.hs
@@ -4,7 +4,7 @@ module Examples (examples) where
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Default (def)
-import SMTLIB.Backends (QueuingFlag (..), command, command_, initSolver)
+import SMTLIB.Backends (QueuingFlag (..), command, initSolver)
 import qualified SMTLIB.Backends.Process as Process
 import System.Exit (ExitCode (ExitSuccess))
 import System.IO (BufferMode (LineBuffering), hSetBuffering)
@@ -74,12 +74,11 @@ manualExit :: IO ()
 manualExit = do
   -- launch a new process with 'Process.new'
   handle <- Process.new def
-  let backend = Process.toBackend handle
-  -- here we disable queuing so that we can use 'command_' to ensure the exit
-  -- command will be received successfully
-  solver <- initSolver NoQueuing backend
-  command_ solver "(exit)"
-  -- 'Process.wait' takes care of cleaning resources and waits for the process to
-  -- exit
+  -- to stop the process, we first send an "(exit)" command and then use
+  -- 'Process.wait' which takes care of cleaning resources and waits for the
+  -- process to actually exit
+  -- when an exit code isn't needed and the process doesn't have to stop
+  -- gracefully, another simpler option is to just use 'Process.close'
+  Process.exit handle
   exitCode <- Process.wait handle
   assertBool "the solver process didn't exit properly" $ exitCode == ExitSuccess

--- a/smtlib-backends-process/tests/Main.hs
+++ b/smtlib-backends-process/tests/Main.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 import Data.Default (def)
 import Examples (examples)
 import qualified SMTLIB.Backends.Process as Process
 import SMTLIB.Backends.Tests (sources, testBackend)
 import Test.Tasty
+import Test.Tasty.HUnit
 
 main :: IO ()
 main = do
@@ -11,5 +14,9 @@ main = do
       "Tests"
       [ testBackend "Basic examples" sources $ \todo ->
           Process.with def $ todo . Process.toBackend,
-        testGroup "API usage examples" examples
+        testGroup "API usage examples" examples,
+        testCase "Piling up stopping procedures" $ Process.with def $ \handle -> do
+          Process.write handle "(exit)"
+          _ <- Process.close handle
+          Process.kill handle
       ]


### PR DESCRIPTION
Currently in `Queuing` mode there is no way to send an `(exit)` command to a `Process` backend, as it needs to actually be evaluated immediately but won't make the solver output anything. Using `Bck.(send . backend)` will thus leave the process hanging while waiting for a response that will never come.

This PR fixes this by adding an `exit` function in the `Process` module. It makes sense to keep this inside this module as this is something backend-specific: the `(exit)` command doesn't have any effect when using the `Z3` backend. The implementation uses another function, `write`, which factors the instructions for writing onto the process' input channel.

I'm not sure whether it is best to keep this `exit` function on its own or to just merge it with the `with` function instead. They latter will always be used with the former anyways but it seems SMTLIB-based projects always separate these two functions.
Another thing I'm wondering is whether this function's name could be any better. It might get confusing for the user to have access to `exit`, `wait` and `close`.