### PR TITLE
Remove content of hie.yaml

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -1,10 +1,2 @@
 cradle:
   cabal:
-    - path: "./Z3/src"
-      component: "smtlib-backends-z3:libs"
-    - path: "./Z3/tests"
-      component: "smtlib-backends-z3:tests"
-    - path: "./src/"
-      component: "smtlib-backends:libs"
-    - path: "./tests/src"
-      component: "smtlib-backends:tests"


### PR DESCRIPTION
Works alright like that, and avoids de-synchronisation between the paths of `hie.yaml` and the actual paths in the repo