### PR TITLE
Add Process.defaultConfig and Z3.defaultConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` an
 - **(breaking change)** add a datatype `Backend.QueuingFlag` to set the queuing mode
   - the `initSolver` function now takes this datatype as argument instead of a 
     boolean
-- add `Process.defaultConfig` and `Z3.defaultConfig`
 
 # v0.2
 - split the `Process` module into its own library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` an
 - **(breaking change)** add a datatype `Backend.QueuingFlag` to set the queuing mode
   - the `initSolver` function now takes this datatype as argument instead of a 
     boolean
+- add `Process.defaultConfig` and `Z3.defaultConfig`
 
 # v0.2
 - split the `Process` module into its own library

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -10,6 +10,7 @@
   solver's response
 - add a test checking that we can pile up procedures for exiting a process
   safely
+- add `Process.defaultConfig`, synonym for `def`
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -49,7 +49,6 @@ test-suite test
   build-depends:
       base
     , bytestring
-    , data-default
     , smtlib-backends
     , smtlib-backends-process
     , smtlib-backends-tests

--- a/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
+++ b/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
@@ -8,6 +8,7 @@
 module SMTLIB.Backends.Process
   ( Config (..),
     Handle (..),
+    defaultConfig,
     new,
     write,
     close,
@@ -59,11 +60,14 @@ data Config = Config
     reportError :: LBS.ByteString -> IO ()
   }
 
--- | By default, use Z3 as an external process and ignore log messages.
+-- | By default, use Z3 as an external process and ignores log messages.
+defaultConfig :: Config
+-- if you change this, make sure to also update the comment two lines above
+-- as well as the one in @smtlib-backends-process/tests/Examples.hs@
+defaultConfig = Config "z3" ["-in"] (\_ -> return ())
+
 instance Default Config where
-  -- if you change this, make sure to also update the comment two lines above
-  -- as well as the one in @smtlib-backends-process/tests/Examples.hs@
-  def = Config "z3" ["-in"] $ const $ return ()
+  def = defaultConfig
 
 data Handle = Handle
   { -- | The process running the solver.

--- a/smtlib-backends-process/tests/Examples.hs
+++ b/smtlib-backends-process/tests/Examples.hs
@@ -3,7 +3,6 @@
 module Examples (examples) where
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.Default (def)
 import SMTLIB.Backends (QueuingFlag (..), command, initSolver)
 import qualified SMTLIB.Backends.Process as Process
 import System.IO (BufferMode (LineBuffering), hSetBuffering)
@@ -25,10 +24,8 @@ basicUse :: IO ()
 basicUse =
   -- 'Process.with' runs a computation using the 'Process' backend
   Process.with
-    -- the configuration type 'Process.Config' is an instance of the 'Default' class
-    -- we can thus use a default configuration for the backend with the 'def' method
-    -- this default configuration uses Z3 as an external process and disables logging
-    def
+    -- the default configuration uses Z3 as an external process and disables logging
+    Process.defaultConfig
     $ \handle -> do
       -- first, we make the process handle into an actual backend
       let backend = Process.toBackend handle
@@ -74,7 +71,7 @@ setOptions =
 manualExit :: IO ()
 manualExit = do
   -- launch a new process with 'Process.new'
-  handle <- Process.new def
+  handle <- Process.new Process.defaultConfig
   -- do some stuff
   doStuffWithHandle handle
   -- kill the process with 'Process.kill'

--- a/smtlib-backends-process/tests/Main.hs
+++ b/smtlib-backends-process/tests/Main.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.Default (def)
 import Examples (examples)
 import qualified SMTLIB.Backends.Process as Process
 import SMTLIB.Backends.Tests (sources, testBackend)
@@ -13,10 +12,11 @@ main = do
     testGroup
       "Tests"
       [ testBackend "Basic examples" sources $ \todo ->
-          Process.with def $ todo . Process.toBackend,
+          Process.with Process.defaultConfig $ todo . Process.toBackend,
         testGroup "API usage examples" examples,
-        testCase "Piling up stopping procedures" $ Process.with def $ \handle -> do
-          Process.write handle "(exit)"
-          _ <- Process.close handle
-          Process.kill handle
+        testCase "Piling up stopping procedures" $
+          Process.with Process.defaultConfig $ \handle -> do
+            Process.write handle "(exit)"
+            _ <- Process.close handle
+            Process.kill handle
       ]

--- a/smtlib-backends-z3/CHANGELOG.md
+++ b/smtlib-backends-z3/CHANGELOG.md
@@ -4,6 +4,7 @@
 object as argument, which one may use to set some solver options at initialization
 time
     - add corresponding examples in the test-suite
+- add `Z3.defaultConfig`, synonym for `def`
 
 # v0.2
 - make test-suite compatible with `smtlib-backends-0.2`

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -60,7 +60,6 @@ test-suite test
   build-depends:
       base
     , bytestring
-    , data-default
     , smtlib-backends
     , smtlib-backends-tests
     , smtlib-backends-z3

--- a/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
+++ b/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
@@ -7,6 +7,7 @@
 module SMTLIB.Backends.Z3
   ( Config (..),
     Handle,
+    defaultConfig,
     new,
     close,
     with,
@@ -58,8 +59,11 @@ newtype Config = Config
   }
 
 -- | By default, don't set any options during initialization.
+defaultConfig :: Config
+defaultConfig = Config []
+
 instance Default Config where
-  def = Config []
+  def = defaultConfig
 
 newtype Handle = Handle
   { -- | A black-box representing the internal state of the solver.

--- a/smtlib-backends-z3/tests/Examples.hs
+++ b/smtlib-backends-z3/tests/Examples.hs
@@ -3,7 +3,6 @@
 module Examples (examples) where
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.Default (def)
 import SMTLIB.Backends (QueuingFlag (..), command, command_, initSolver)
 import qualified SMTLIB.Backends.Z3 as Z3
 import Test.Tasty
@@ -23,7 +22,7 @@ basicUse =
   -- it takes a configuration object as argument, whose use we describe in
   -- 'settingOptions'
   -- here we just use the default configuration, literally @'Z3.Config' []@
-  Z3.with def $ \handle -> do
+  Z3.with Z3.defaultConfig $ \handle -> do
     -- first, we make the z3 handle into an actual backend
     let backend = Z3.toBackend handle
     -- then, we create a solver out of the backend
@@ -42,7 +41,7 @@ settingOptions =
   -- set when the object representing the state of the solver is created
   -- hence the 'Z3.new' and 'Z3.with' functions allow for setting options at
   -- initialization time
-  Z3.with def
+  Z3.with Z3.defaultConfig
   -- (Z3.Config [(":produce-unsat-cores", "true")])
   $
     \handle -> do

--- a/smtlib-backends-z3/tests/Main.hs
+++ b/smtlib-backends-z3/tests/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.Default (def)
 import Examples (examples)
 import SMTLIB.Backends
 import SMTLIB.Backends.Tests
@@ -19,7 +18,7 @@ main = do
         testBackend "Error handling" failingSources z3
       ]
   where
-    z3 todo = Z3.with def $ todo . Z3.toBackend
+    z3 todo = Z3.with Z3.defaultConfig $ todo . Z3.toBackend
     validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
     failingSources =
       [ Source "invalid command" $ \solver -> do


### PR DESCRIPTION
`defaultConfig` makes for a more descriptive name in code than `def`.