### PR TITLE
Backend: add `unsafeCommand_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` an
 - **(breaking change)** add a datatype `Backend.QueuingFlag` to set the queuing mode
   - the `initSolver` function now takes this datatype as argument instead of a 
     boolean
+- add `Backend.unsafeCommand_`, a thread-unsafe version of `Backend.command_`
 
 # v0.2
 - split the `Process` module into its own library


### PR DESCRIPTION
Currently `putQueue` is implemented using `atomicModifyIORef`. This is thread-safe hence slower than using `modifyIORef`. This PR adds an unsafe version of `putQueue` and hence of `command_` for the users who don't care about thread-safety.