### PR TITLE
add `send_` and `flushQueue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` and 
+see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` and
 `smtlib-backends-z3`
 
 # v0.3-alpha
-- **(breaking change)** add a datatype `Backend.QueuingFlag` to set the queuing mode
-  - the `initSolver` function now takes this datatype as argument instead of a 
+- **(breaking change)** add a datatype `Backends.QueuingFlag` to set the queuing mode
+  - the `initSolver` function now takes this datatype as argument instead of a
     boolean
 - **(breaking change)** make the queuing functions thread-unsafe but faster
+- add a `send_` method to the `Backends.Backend` datatype for sending commands with no output
+- add a `Backends.flushQueue` function for forcing the content of the queue to be
+  evaluated
 
 # v0.2
 - split the `Process` module into its own library
@@ -14,4 +17,3 @@ see also the changelogs of `smtlib-backends-tests`, `smtlib-backends-process` an
   - the user can always surround `command` or `command_` with their own logging
     functions
 - improve read-me
-

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -6,8 +6,6 @@
   - send an `(exit)` command before waiting for the process to exit
   - this means `Process.with` now closes the process with this new version of
     `Process.close`, hence gracefully
-- add a `Process.write` function for writing commands without reading the
-  solver's response
 - add a test checking that we can pile up procedures for exiting a process
   safely
 - add `Process.defaultConfig`, synonym for `def`
@@ -19,7 +17,7 @@ split `smtlib-backends`'s `Process` module into its own library
 - move the logger function into it
 - make it an instance of the `Default` typeclass
 ## logging
-- move the logger function into the `Config` datatype 
+- move the logger function into the `Config` datatype
 - don't prefix error messages with `[stderr]`
 ## test-suite
 - add usage examples

--- a/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
+++ b/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
@@ -10,7 +10,6 @@ module SMTLIB.Backends.Process
     Handle (..),
     defaultConfig,
     new,
-    write,
     close,
     kill,
     with,

--- a/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
+++ b/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
@@ -162,14 +162,16 @@ pattern c :< rest <- (BS.uncons -> Just (c, rest))
 
 -- | Make the solver process into an SMT-LIB backend.
 toBackend :: Handle -> Backend
-toBackend handle =
-  Backend $ \cmd -> do
-    -- exceptions are decorated inside the body of 'write'
-    write handle cmd
-    decorateIOError "reading solver's response" $
-      toLazyByteString
-        <$> continueNextLine (scanParen 0) mempty
+toBackend handle = Backend backendSend backendSend_
   where
+    backendSend_ = write handle
+    backendSend cmd = do
+      -- exceptions are decorated inside the body of 'write'
+      write handle cmd
+      decorateIOError "reading solver's response" $
+        toLazyByteString
+          <$> continueNextLine (scanParen 0) mempty
+
     -- scanParen read lines from the handle's output channel until it has detected
     -- a complete s-expression, i.e. a well-parenthesized word that may contain
     -- strings, quoted symbols, and comments

--- a/smtlib-backends-process/tests/Examples.hs
+++ b/smtlib-backends-process/tests/Examples.hs
@@ -78,12 +78,6 @@ manualExit = do
   -- kill the process with 'Process.kill'
   -- other options include using 'Process.close' to ensure the process exits
   -- gracefully
-  --
-  -- if this isn't enough for you, it is always possible to send an @(exit)@
-  -- command using 'command_' (see the 'flushing' example), access the solver
-  -- process using 'Process.process' and kill it manually if this is what you go
-  -- with, don't forget to also cancel the 'Process.errorReader' asynchronous
-  -- process!
   Process.kill handle
   where
     doStuffWithHandle _ = return ()

--- a/smtlib-backends-process/tests/Main.hs
+++ b/smtlib-backends-process/tests/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Examples (examples)
+import qualified SMTLIB.Backends as SMT
 import qualified SMTLIB.Backends.Process as Process
 import SMTLIB.Backends.Tests (sources, testBackend)
 import Test.Tasty
@@ -16,7 +17,9 @@ main = do
         testGroup "API usage examples" examples,
         testCase "Piling up stopping procedures" $
           Process.with Process.defaultConfig $ \handle -> do
-            Process.write handle "(exit)"
+            solver <- SMT.initSolver SMT.Queuing $ Process.toBackend handle
+            SMT.command_ solver "(exit)"
+            SMT.flushQueue solver
             _ <- Process.close handle
             Process.kill handle
       ]


### PR DESCRIPTION
Following #48, this PR adds a `send_` method to the `Backends.Backend` datatype. It is used in the body of the new `Backends.flushQueue` function which forces the evaluation of the content of the queue (in queuing mode). 
This PR also removes the `Process.write` since an equivalent behavior can be obtained using `command_` followed by `flushQueue`.