### PR TITLE
`Process`: use `process` instead of `typed-process`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMT-LIB backends
 
 This Haskell library provides different low-level ways of interacting with SMT
-solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
+solvers using [SMT-LIB](http://smtlib.cs.uiowa.edu/).
 
 We currently provide two different backends: a classic backend, available in the
 `smtlib-backends-process` package, implemented by running solvers as external processes,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SMT-LIB backends
 
 This Haskell library provides different low-level ways of interacting with SMT
-solvers using [SMT-LIB](http://smtlib.cs.uiowa.edu/).
+solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
 
 We currently provide two different backends: a classic backend, available in the
 `smtlib-backends-process` package, implemented by running solvers as external processes,

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
             export -f runCabal2nix
             ## We use `bash -c` because shell functions can't be passed to
             ## external processes (`xargs` in that case).
-            find . -name '*.cabal' | xargs -I{} bash -c 'runCabal2nix {}'
+            find . -name '*.cabal' -print0 | xargs --null -I{} bash -c 'runCabal2nix {}'
           '';
         };
       in {

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -11,6 +11,10 @@
   - remove `Process.wait`
   - there is now a single example in the test-suite showing how to 
     manage the underlying process and its I/O channels
+- **(breaking change)** removed logging capabilities, this is now on the user to
+  implement
+  - remove `Config`'s `reportError` field
+  - remove `Handle`'s `errorReader` field
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -1,17 +1,16 @@
 # v0.3-alpha
 - make test-suite compatible with `smtlib-backends-0.3`
-- **(breaking change)** rename `Process.close` to `Process.kill`
-- **(breaking change)** rename `Process.wait` to `Process.close` and improve it
-  - ensure the process gets killed even if an error is caught
-  - send an `(exit)` command before waiting for the process to exit
-  - this means `Process.with` now closes the process with this new version of
-    `Process.close`, hence gracefully
 - add tests for documenting edge cases of the backends
   - check that we can pile up procedures for exiting a process
   - what happens when sending an empty command
   - what happens when sending a command not producing any output
 - add `Process.defaultConfig`, synonym for `def`
 - improve error messages inside `Process.toBackend`
+- **(breaking change)** use `process` instead of `typed-process` to manage the underlying process
+  - change the definition of the `Process.Handle` datatype accordingly
+  - remove `Process.wait`
+  - there is now a single example in the test-suite showing how to 
+    manage the underlying process and its I/O channels
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -50,13 +50,14 @@ test-suite test
 
   ghc-options:      -threaded -Wall -Wunused-packages
   build-depends:
-      base
+      async
+    , base
     , bytestring
+    , process
     , smtlib-backends
     , smtlib-backends-process
     , smtlib-backends-tests
     , tasty
     , tasty-hunit
-    , typed-process
 
   default-language: Haskell2010

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -49,7 +49,8 @@ test-suite test
 
   ghc-options:      -threaded -Wall -Wunused-packages
   build-depends:
-      base
+      async
+    , base
     , bytestring
     , process
     , smtlib-backends

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -35,8 +35,8 @@ library
     , base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
     , data-default     >=0.7.1   && <0.8
+    , process          >=1.6     && <1.7
     , smtlib-backends  >=0.3     && <0.4
-    , typed-process    >=0.2.10  && <0.3
 
   default-language: Haskell2010
 

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -31,8 +31,7 @@ library
   exposed-modules:  SMTLIB.Backends.Process
   other-extensions: Safe
   build-depends:
-      async            >=2.2.4   && <2.3
-    , base             >=4.14    && <4.18
+      base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
     , data-default     >=0.7.1   && <0.8
     , process          >=1.6     && <1.7
@@ -50,8 +49,7 @@ test-suite test
 
   ghc-options:      -threaded -Wall -Wunused-packages
   build-depends:
-      async
-    , base
+      base
     , bytestring
     , process
     , smtlib-backends

--- a/smtlib-backends-process/smtlib-backends-process.nix
+++ b/smtlib-backends-process/smtlib-backends-process.nix
@@ -9,11 +9,11 @@ mkDerivation {
   version = "0.3";
   src = ./.;
   libraryHaskellDepends = [
-    async base bytestring data-default smtlib-backends typed-process
+    async base bytestring data-default process smtlib-backends
   ];
   testHaskellDepends = [
-    base bytestring data-default smtlib-backends smtlib-backends-tests
-    tasty tasty-hunit typed-process
+    base bytestring data-default process smtlib-backends
+    smtlib-backends-tests tasty tasty-hunit
   ];
   description = "An SMT-LIB backend running solvers as external processes";
   license = lib.licenses.mit;

--- a/smtlib-backends-process/smtlib-backends-process.nix
+++ b/smtlib-backends-process/smtlib-backends-process.nix
@@ -1,8 +1,7 @@
 ## This file has been generated automatically.
 ## Run `nix run .#makeBackendsDerivation` to update it.
-{ mkDerivation, async, base, bytestring, data-default, lib
+{ mkDerivation, async, base, bytestring, data-default, lib, process
 , smtlib-backends, smtlib-backends-tests, tasty, tasty-hunit
-, typed-process
 }:
 mkDerivation {
   pname = "smtlib-backends-process";
@@ -12,8 +11,8 @@ mkDerivation {
     async base bytestring data-default process smtlib-backends
   ];
   testHaskellDepends = [
-    base bytestring data-default process smtlib-backends
-    smtlib-backends-tests tasty tasty-hunit
+    async base bytestring process smtlib-backends smtlib-backends-tests
+    tasty tasty-hunit
   ];
   description = "An SMT-LIB backend running solvers as external processes";
   license = lib.licenses.mit;

--- a/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
+++ b/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
@@ -31,8 +31,6 @@ import Data.Default (Default, def)
 import GHC.IO.Exception (IOException (ioe_description))
 import SMTLIB.Backends (Backend (..))
 import qualified System.IO as IO
--- we use process instead of typed-process because of a race condition in
--- killing a process: https://github.com/fpco/typed-process/issues/38
 import System.Process as P
 
 data Config = Config

--- a/smtlib-backends-process/tests/EdgeCases.hs
+++ b/smtlib-backends-process/tests/EdgeCases.hs
@@ -6,6 +6,7 @@ import Data.ByteString.Builder (Builder)
 import Data.ByteString.Lazy.Char8 as LBS
 import SMTLIB.Backends as SMT
 import qualified SMTLIB.Backends.Process as Process
+import System.Process (terminateProcess, waitForProcess)
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -21,7 +22,10 @@ edgeCases =
 pileUpStops :: IO ()
 pileUpStops = Process.with Process.defaultConfig $ \handle -> do
   let backend = Process.toBackend handle
+      process = Process.process handle
   SMT.send_ backend "(exit)"
+  _ <- waitForProcess process
+  terminateProcess process
 
 -- | Upon processing an empty command, the backend will not respond.
 emptyCommand :: IO ()

--- a/smtlib-backends-process/tests/Examples.hs
+++ b/smtlib-backends-process/tests/Examples.hs
@@ -3,7 +3,6 @@
 
 module Examples (examples) where
 
-import Control.Concurrent.Async (cancel)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import SMTLIB.Backends (QueuingFlag (..), command, command_, flushQueue, initSolver)
 import qualified SMTLIB.Backends.Process as Process
@@ -50,8 +49,7 @@ setOptions =
   let myConfig =
         Process.Config
           { Process.exe = "z3",
-            Process.args = ["-in", "solver.timeout=10000"],
-            Process.reportError = LBS.putStr . (`LBS.snoc` '\n')
+            Process.args = ["-in", "solver.timeout=10000"]
           }
    in Process.with myConfig $ \handle -> do
         solver <- initSolver Queuing $ Process.toBackend handle
@@ -79,7 +77,6 @@ underlyingProcess = do
   -- if you don't like this, you can always send it an @(exit)@ command and wait
   -- for it to end, but make sure you also release its other resources
   LBS.hPutStrLn hIn "(exit)"
-  cancel errorReader
   mapM_ hClose [hIn, hOut, hErr]
   _ <- waitForProcess process
   return ()

--- a/smtlib-backends-z3/smtlib-backends-z3.nix
+++ b/smtlib-backends-z3/smtlib-backends-z3.nix
@@ -13,8 +13,8 @@ mkDerivation {
   ];
   librarySystemDepends = [ gomp z3 ];
   testHaskellDepends = [
-    base bytestring data-default smtlib-backends smtlib-backends-tests
-    tasty tasty-hunit
+    base bytestring smtlib-backends smtlib-backends-tests tasty
+    tasty-hunit
   ];
   description = "An SMT-LIB backend implemented using Z3's C API";
   license = lib.licenses.mit;


### PR DESCRIPTION
The use of the `typed-process` library is at the root of #15. This PR replaces it with the `process` library it builds upon anyways. Notable changes include
- the `Process.wait` function was removed: it's not strictly necessary and was annoying to implement as `waitForProcess` doesn't automatically close the I/O handles
- the `manualExit` and `settingOptions` (its advanced part) examples were merged into the new `underlyingProcess` example, which shows how to use the internals of the `Handle` datatype to tweak the behavior of the process and close it manually

Before merging this, we should check that
- [x] this indeed solves #15 and gets rid of the failures in the CI of https://github.com/ucsd-progsys/liquid-fixpoint/pull/641