### PR TITLE
release version 0.3

### DIFF
--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -22,7 +22,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag:      0.2
+  tag:      0.3
   subdir:   smtlib-backends-process
 
 library

--- a/smtlib-backends-tests/smtlib-backends-tests.cabal
+++ b/smtlib-backends-tests/smtlib-backends-tests.cabal
@@ -22,7 +22,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag:      0.2
+  tag:      0.3
   subdir:   smtlib-backends-tests
 
 library

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -24,7 +24,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag:      0.2
+  tag:      0.3
   subdir:   smtlib-backends-z3
 
 library

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -25,7 +25,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/tweag/smtlib-backends
-  tag:      0.2
+  tag:      0.3
 
 library
   hs-source-dirs:   src


### PR DESCRIPTION
This PR prepares the repository for the release of version 0.3.
Things that need to be done
- [x] bump versions in the cabal files
- [ ] merge #55 
- [ ] update the changelogs and format them according to https://keepachangelog.com/en/1.0.0/
- [ ] (optional) add documentation for values which aren't documented yet, as Haddock currently complains that the following aren't documented:
  - smtlib-backends: Module header 
  - smtlib-backends-process: 
    -  Config (src/SMTLIB/Backends/Process.hs:51) 
    - Handle (src/SMTLIB/Backends/Process.hs:72)
  - smtlib-backends-z3
    - Config (src/SMTLIB/Backends/Z3.hs:54)
    - Handle (src/SMTLIB/Backends/Z3.hs:68)

