### PR TITLE
Remove unused instances of Data.Default

### DIFF
--- a/smtlib-backends-process/CHANGELOG.md
+++ b/smtlib-backends-process/CHANGELOG.md
@@ -15,6 +15,7 @@
   implement
   - remove `Config`'s `reportError` field
   - remove `Handle`'s `errorReader` field
+- **(breaking change)** removed `Data.Default` instance of `Config`
 
 # v0.2
 split `smtlib-backends`'s `Process` module into its own library

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -33,7 +33,6 @@ library
   build-depends:
       base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
-    , data-default     >=0.7.1   && <0.8
     , process          >=1.6     && <1.7
     , smtlib-backends  >=0.3     && <0.4
 

--- a/smtlib-backends-process/smtlib-backends-process.nix
+++ b/smtlib-backends-process/smtlib-backends-process.nix
@@ -1,6 +1,6 @@
 ## This file has been generated automatically.
 ## Run `nix run .#makeBackendsDerivation` to update it.
-{ mkDerivation, async, base, bytestring, data-default, lib, process
+{ mkDerivation, async, base, bytestring, lib, process
 , smtlib-backends, smtlib-backends-tests, tasty, tasty-hunit
 }:
 mkDerivation {
@@ -8,7 +8,7 @@ mkDerivation {
   version = "0.3";
   src = ./.;
   libraryHaskellDepends = [
-    async base bytestring data-default process smtlib-backends
+    async base bytestring process smtlib-backends
   ];
   testHaskellDepends = [
     async base bytestring process smtlib-backends smtlib-backends-tests

--- a/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
+++ b/smtlib-backends-process/src/SMTLIB/Backends/Process.hs
@@ -24,7 +24,6 @@ import Data.ByteString.Builder
     toLazyByteString,
   )
 import qualified Data.ByteString.Char8 as BS
-import Data.Default (Default, def)
 import GHC.IO.Exception (IOException (ioe_description))
 import SMTLIB.Backends (Backend (..))
 import qualified System.IO as IO
@@ -42,9 +41,6 @@ defaultConfig :: Config
 -- if you change this, make sure to also update the comment two lines above
 -- as well as the one in @smtlib-backends-process/tests/Examples.hs@
 defaultConfig = Config "z3" ["-in"]
-
-instance Default Config where
-  def = defaultConfig
 
 data Handle = Handle
   { -- | The process running the solver.

--- a/smtlib-backends-z3/CHANGELOG.md
+++ b/smtlib-backends-z3/CHANGELOG.md
@@ -8,6 +8,7 @@ time
 - add tests for documenting edge cases of the backends
   - what happens when sending an empty command
   - what happens when sending a command not producing any output
+- **(breaking change)** removed `Data.Default` instance of `Config`
 
 # v0.2
 - make test-suite compatible with `smtlib-backends-0.2`

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -35,7 +35,6 @@ library
       base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
     , containers       >=0.6.4   && <0.7
-    , data-default     >=0.7     && <0.8
     , inline-c         >=0.9.1   && <0.10
     , smtlib-backends  >=0.3     && <0.4
 

--- a/smtlib-backends-z3/smtlib-backends-z3.nix
+++ b/smtlib-backends-z3/smtlib-backends-z3.nix
@@ -1,6 +1,6 @@
 ## This file has been generated automatically.
 ## Run `nix run .#makeBackendsDerivation` to update it.
-{ mkDerivation, base, bytestring, containers, data-default, gomp
+{ mkDerivation, base, bytestring, containers, gomp
 , inline-c, lib, smtlib-backends, smtlib-backends-tests, tasty
 , tasty-hunit, z3
 }:
@@ -9,7 +9,7 @@ mkDerivation {
   version = "0.3";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring containers data-default inline-c smtlib-backends
+    base bytestring containers inline-c smtlib-backends
   ];
   librarySystemDepends = [ gomp z3 ];
   testHaskellDepends = [

--- a/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
+++ b/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
@@ -25,7 +25,6 @@ import Data.ByteString.Builder.Extra
   )
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import Data.Default
 import qualified Data.Map as M
 import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr)
 import Foreign.Ptr (Ptr)
@@ -61,9 +60,6 @@ newtype Config = Config
 -- | By default, don't set any options during initialization.
 defaultConfig :: Config
 defaultConfig = Config []
-
-instance Default Config where
-  def = defaultConfig
 
 newtype Handle = Handle
   { -- | A black-box representing the internal state of the solver.

--- a/smtlib-backends-z3/tests/EdgeCases.hs
+++ b/smtlib-backends-z3/tests/EdgeCases.hs
@@ -3,7 +3,6 @@
 module EdgeCases (edgeCases) where
 
 import Data.ByteString.Builder (Builder)
-import Data.ByteString.Lazy.Char8 as LBS
 import SMTLIB.Backends as SMT
 import qualified SMTLIB.Backends.Z3 as Z3
 import Test.Tasty


### PR DESCRIPTION
We don't use these instances, and I think we don't want to encourage usage of this pattern.

Moreover, the one user that needs them can define them herself.