### PR TITLE
Drop dependency on inline-c in the Z3 backend

### DIFF
--- a/smtlib-backends-z3/CHANGELOG.md
+++ b/smtlib-backends-z3/CHANGELOG.md
@@ -9,6 +9,7 @@ time
   - what happens when sending an empty command
   - what happens when sending a command not producing any output
 - **(breaking change)** removed `Data.Default` instance of `Config`
+- dropped dependency on `inline-c`
 
 # v0.2
 - make test-suite compatible with `smtlib-backends-0.2`

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -34,8 +34,6 @@ library
   build-depends:
       base             >=4.14    && <4.18
     , bytestring       >=0.10.12 && <0.12
-    , containers       >=0.6.4   && <0.7
-    , inline-c         >=0.9.1   && <0.10
     , smtlib-backends  >=0.3     && <0.4
 
   -- inspired from haskell-z3

--- a/smtlib-backends-z3/smtlib-backends-z3.nix
+++ b/smtlib-backends-z3/smtlib-backends-z3.nix
@@ -1,7 +1,7 @@
 ## This file has been generated automatically.
 ## Run `nix run .#makeBackendsDerivation` to update it.
-{ mkDerivation, base, bytestring, containers, gomp
-, inline-c, lib, smtlib-backends, smtlib-backends-tests, tasty
+{ mkDerivation, base, bytestring, gomp
+, lib, smtlib-backends, smtlib-backends-tests, tasty
 , tasty-hunit, z3
 }:
 mkDerivation {
@@ -9,7 +9,7 @@ mkDerivation {
   version = "0.3";
   src = ./.;
   libraryHaskellDepends = [
-    base bytestring containers inline-c smtlib-backends
+    base bytestring smtlib-backends
   ];
   librarySystemDepends = [ gomp z3 ];
   testHaskellDepends = [

--- a/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
+++ b/smtlib-backends-z3/src/SMTLIB/Backends/Z3.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CApiFFI #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -17,38 +18,23 @@ where
 
 import Control.Exception (bracket)
 import Control.Monad (forM_, void)
+import qualified Data.ByteString as BS
 import Data.ByteString.Builder.Extra
   ( defaultChunkSize,
     smallChunkSize,
     toLazyByteStringWith,
     untrimmedStrategy,
   )
-import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import qualified Data.Map as M
-import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr)
-import Foreign.Ptr (Ptr)
-import qualified Language.C.Inline as C
-import qualified Language.C.Inline.Context as C
-import qualified Language.C.Inline.Unsafe as CU
-import qualified Language.C.Types as C
+import qualified Data.ByteString.Unsafe
+import Foreign.C.String (CString)
+import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr, withForeignPtr)
+import Foreign.Ptr (FunPtr, Ptr, nullPtr)
 import SMTLIB.Backends (Backend (..))
 
 data Z3Context
 
 data Z3Config
-
-C.context
-  ( C.baseCtx
-      <> C.fptrCtx
-      <> C.bsCtx
-      <> mempty
-        { C.ctxTypesTable =
-            M.singleton (C.TypeName "Z3_context") [t|Ptr Z3Context|]
-              <> M.singleton (C.TypeName "Z3_config") [t|Ptr Z3Config|]
-        }
-  )
-C.include "z3.h"
 
 newtype Config = Config
   { -- | A list of options to set during the solver's initialization.
@@ -66,37 +52,40 @@ newtype Handle = Handle
     context :: ForeignPtr Z3Context
   }
 
+foreign import capi unsafe "z3.h &Z3_del_context" c_Z3_del_context :: FunPtr (Ptr Z3Context -> IO ())
+
+foreign import capi unsafe "z3.h Z3_set_param_value" c_Z3_set_param_value :: Ptr Z3Config -> CString -> CString -> IO ()
+
+foreign import capi unsafe "z3.h Z3_mk_config" c_Z3_mk_config :: IO (Ptr Z3Config)
+
+foreign import capi unsafe "z3.h Z3_mk_context" c_Z3_mk_context :: Ptr Z3Config -> IO (Ptr Z3Context)
+
+foreign import capi unsafe "z3.h Z3_del_config" c_Z3_del_config :: Ptr Z3Config -> IO ()
+
+foreign import capi unsafe "z3.h Z3_set_error_handler" c_Z3_set_error_handler :: Ptr Z3Context -> Ptr () -> IO ()
+
+-- We use ccall to avoid warnings about constness in the C side
+foreign import ccall unsafe "z3.h Z3_eval_smtlib2_string" c_Z3_eval_smtlib2_string :: Ptr Z3Context -> CString -> IO CString
+
 -- | Create a new solver instance.
 new :: Config -> IO Handle
 new config = do
-  let ctxFinalizer =
-        [C.funPtr| void free_context(Z3_context ctx) {
-                 Z3_del_context(ctx);
-                 } |]
   -- we don't set a finalizer for this object as we manually delete it during the
   -- context's creation
-  cfg <- [CU.exp| Z3_config { Z3_mk_config() } |]
+  cfg <- c_Z3_mk_config
   forM_ (parameters config) $ \(paramId, paramValue) ->
-    [CU.exp| void { Z3_set_param_value($(Z3_config cfg),
-                                       $bs-ptr:paramId,
-                                       $bs-ptr:paramValue)
-           } |]
+    BS.useAsCString paramId $ \cparamId ->
+      BS.useAsCString paramValue $ \cparamValue ->
+        c_Z3_set_param_value cfg cparamId cparamValue
   {-
   We set the error handler to ignore errors. That way if an error happens it doesn't
   cause the whole program to crash, and the error message is simply transmitted to
   the Haskell layer inside the output of the 'send' method.
   -}
-  ctx <-
-    newForeignPtr ctxFinalizer
-      =<< [CU.block| Z3_context {
-                 Z3_context ctx = Z3_mk_context($(Z3_config cfg));
-                 Z3_del_config($(Z3_config cfg));
-
-                 void ignore_error(Z3_context c, Z3_error_code e) {}
-                 Z3_set_error_handler(ctx, ignore_error);
-
-                 return ctx;
-                 } |]
+  pctx <- c_Z3_mk_context cfg
+  c_Z3_del_config cfg
+  c_Z3_set_error_handler pctx nullPtr
+  ctx <- newForeignPtr c_Z3_del_context pctx
   return $ Handle ctx
 
 -- | Release the resources associated with a Z3 instance.
@@ -119,10 +108,9 @@ toBackend handle = Backend backendSend backendSend_
                 (untrimmedStrategy smallChunkSize defaultChunkSize)
                 "\NUL"
                 cmd
-      LBS.fromStrict
-        <$> ( BS.packCString
-                =<< [CU.exp| const char* {
-               Z3_eval_smtlib2_string($fptr-ptr:(Z3_context ctx), $bs-ptr:cmd')
-               }|]
-            )
+      Data.ByteString.Unsafe.unsafeUseAsCString cmd' $ \ccmd' ->
+        withForeignPtr ctx $ \pctx -> do
+          resp <- c_Z3_eval_smtlib2_string pctx ccmd'
+          LBS.fromStrict <$> BS.packCString resp
+
     backendSend_ = void . backendSend


### PR DESCRIPTION
`inline-c` requires many dependencies and also requires using TH. The FFI alone suffices for the small code that we have in the Z3 backend.