### PR TITLE
changing of the project's maintainers

### DIFF
--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -8,7 +8,9 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
+maintainer:
+  facundo.dominguez@tweag.io, gabriel.hondet@tweag.io, mathieu.montin@tweag.io
+
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10

--- a/smtlib-backends-process/smtlib-backends-process.cabal
+++ b/smtlib-backends-process/smtlib-backends-process.cabal
@@ -8,7 +8,7 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         quentin.aristote@tweag.io
+maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10

--- a/smtlib-backends-tests/smtlib-backends-tests.cabal
+++ b/smtlib-backends-tests/smtlib-backends-tests.cabal
@@ -8,7 +8,7 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         quentin.aristote@tweag.io
+maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
 build-type:         Simple
 category:           SMT, Testing
 cabal-version:      >=1.10

--- a/smtlib-backends-tests/smtlib-backends-tests.cabal
+++ b/smtlib-backends-tests/smtlib-backends-tests.cabal
@@ -8,7 +8,9 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
+maintainer:
+  facundo.dominguez@tweag.io, gabriel.hondet@tweag.io, mathieu.montin@tweag.io
+
 build-type:         Simple
 category:           SMT, Testing
 cabal-version:      >=1.10

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -10,7 +10,9 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
+maintainer:
+  facundo.dominguez@tweag.io, gabriel.hondet@tweag.io, mathieu.montin@tweag.io
+
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10
@@ -29,7 +31,7 @@ source-repository this
 
 library
   hs-source-dirs:   src
-  c-sources: cbits/z3.c
+  c-sources:        cbits/z3.c
   ghc-options:      -Wall -Wunused-packages
   exposed-modules:  SMTLIB.Backends.Z3
   build-depends:

--- a/smtlib-backends-z3/smtlib-backends-z3.cabal
+++ b/smtlib-backends-z3/smtlib-backends-z3.cabal
@@ -10,7 +10,7 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         quentin.aristote@tweag.io
+maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -12,7 +12,7 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         quentin.aristote@tweag.io
+maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10

--- a/smtlib-backends.cabal
+++ b/smtlib-backends.cabal
@@ -12,7 +12,9 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Quentin Aristote
-maintainer:         facundo.dominguez@tweag.io, gabriel.hondet@tweag.io
+maintainer:
+  facundo.dominguez@tweag.io, gabriel.hondet@tweag.io, mathieu.montin@tweag.io
+
 build-type:         Simple
 category:           SMT
 cabal-version:      >=1.10


### PR DESCRIPTION
I'll be leaving Tweag next week and won't be maintaining the library anymore. This PR changes the listed maintainers in the `.cabal` files. Feel free to add / remove yourself from the `maintainer` field :)