### PR TITLE
Experimental version of `smtlib-backends-cvc5`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 This Haskell library provides different low-level ways of interacting with SMT
 solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
 
-We currently provide two different backends: a classic backend, available in the
-`smtlib-backends-process` package, implemented by running solvers as external processes,
-and a faster backend, available in the `smtlib-backends-z3` package, implemented using Z3
-as a library.
+We currently provide the following backends:
+* a classic backend, available in the `smtlib-backends-process` package, implemented by
+  running solvers as external processes,
+* a faster backend, available in the `smtlib-backends-z3` package, implemented using Z3
+  as a library, and
+* an experimental backend, available in the `smtlib-backends-cvc5` package, implemented
+  using an unstable version of CVC5 as a library.
 
 In addition, the API allows for queuing commands so that they are sent to the backend
 only when a response is needed, as we have observed this to reduce the communication
@@ -37,6 +40,7 @@ respective test-suites:
 - [examples for the `Process`
   backend](smtlib-backends-process/tests/Examples.hs)
 - [examples for the `Z3` backend](smtlib-backends-z3/tests/Examples.hs)
+- [examples for the `CVC5` backend](smtlib-backends-cvc5/tests/Examples.hs)
 
 ## Building and testing
 
@@ -45,7 +49,7 @@ flake](https://www.tweag.io/blog/2020-05-25-flakes/).
 
 Another option is to manually install Z3 to use the process backend, and the Z3
 C library to use the Z3 backend. Then you can build and test the libraries using
-`cabal build` and `cabal test`.
+`cabal build` and `cabal test`. It works analogously if using CVC5 as a library.
 
 ## Implementing backends
 

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,4 @@ packages: ./
           smtlib-backends-process/
           smtlib-backends-tests/
           smtlib-backends-z3/
+          smtlib-backends-cvc5/

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673301451,
-        "narHash": "sha256-0IvOqAXZ+dHjOV7dQl4iEcCUmzqg8VvGg+UZ68ONDIg=",
+        "lastModified": 1701127912,
+        "narHash": "sha256-x/UtyZX/ep6YVENzwcLn+71rwhl70vnUZTuZq7/XFYg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35f1f865c03671a4f75a6996000f03ac3dc3e472",
+        "rev": "c76b72caa421e31d998e4a05387ebd3b40454327",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,8 @@
         src = pkgs.fetchFromGitHub {
           owner  = "cvc5";
           repo   = "cvc5";
-          rev    = "a33daf1b313f71332a00cc4556577962cc731bd2";
-          hash  = "sha256-uKIKjsBs4neC2ZotOeyHO6ddY3CCqwoePB7gfvVogHY=";
+          rev    = "115d3d200b304e234cfd97f0eec861a620d5c998";
+          hash  = "sha256-sZ6nTLyyddatt4r4LcW58ULZv9/fjfRfK0eoGNvmUCI=";
         };
         nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.flex ];
         buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs;
 
   outputs = {
     self,
@@ -8,6 +9,20 @@
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
+      cvc5_latest = pkgs.cvc5.overrideAttrs (old: {
+        version = "2023-11-27";
+        src = pkgs.fetchFromGitHub {
+          owner  = "cvc5";
+          repo   = "cvc5";
+          rev    = "a33daf1b313f71332a00cc4556577962cc731bd2";
+          hash  = "sha256-uKIKjsBs4neC2ZotOeyHO6ddY3CCqwoePB7gfvVogHY=";
+        };
+        nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.flex ];
+        buildInputs = with pkgs; [
+          cadical.dev symfpu gmp gtest libantlr3c antlr3_4 boost jdk
+          (python3.withPackages (ps: with ps; [ pyparsing toml tomli ]))
+        ];
+      });
       hpkgs = pkgs.haskellPackages;
       smtlib-backends = hpkgs.callPackage ./smtlib-backends.nix {};
       smtlib-backends-process = hpkgs.callPackage ./smtlib-backends-process/smtlib-backends-process.nix {
@@ -16,6 +31,10 @@
       smtlib-backends-tests = hpkgs.callPackage ./smtlib-backends-tests/smtlib-backends-tests.nix {inherit smtlib-backends;};
       smtlib-backends-z3 = hpkgs.callPackage ./smtlib-backends-z3/smtlib-backends-z3.nix {
         inherit smtlib-backends smtlib-backends-tests;
+      };
+      smtlib-backends-cvc5 = hpkgs.callPackage ./smtlib-backends-cvc5/smtlib-backends-cvc5.nix {
+        inherit smtlib-backends smtlib-backends-tests;
+        cvc5 = cvc5_latest;
       };
     in {
       formatter = pkgs.alejandra;
@@ -66,12 +85,13 @@
 
       devShells = let
         ## Needed by Z3 tests and haskell language server
-        LD_LIBRARY_PATH = with pkgs; lib.strings.makeLibraryPath [z3];
+        LD_LIBRARY_PATH = with pkgs; lib.strings.makeLibraryPath [z3 cvc5_latest];
         packages = _: [
           smtlib-backends
           smtlib-backends-tests
           smtlib-backends-process
           smtlib-backends-z3
+          smtlib-backends-cvc5
         ];
       in {
         default = hpkgs.shellFor {
@@ -86,14 +106,14 @@
               haskell-language-server
               cabal-fmt
             ])
-            ++ (with pkgs; [z3 ormolu]);
+            ++ (with pkgs; [z3 cvc5_latest ormolu]);
 
           inherit LD_LIBRARY_PATH;
         };
 
         ## Lightweight development shell.
         lightweight = hpkgs.shellFor {
-          buildInputs = with pkgs; [ghc cabal-install z3];
+          buildInputs = with pkgs; [ghc cabal-install z3 cvc5_latest];
           inherit packages;
           inherit LD_LIBRARY_PATH;
         };

--- a/smtlib-backends-cvc5/LICENSE
+++ b/smtlib-backends-cvc5/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Tweag I/O Limited.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/smtlib-backends-cvc5/README.md
+++ b/smtlib-backends-cvc5/README.md
@@ -11,8 +11,9 @@ solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
 
 This libary is currently experimental as it requires the latest version of CVC5
 (github commit a33daf1b313f71332a00cc4556577962cc731bd2 as of writing) which exports
-a CVC5's SMTLIB parser as an API. 
-`smtlib-backends-cvc5 has also only been tested on GHC 9.4, due to this bug on macOS 
+a CVC5's SMTLIB parser as an API.
+
+`smtlib-backends-cvc5` has also only been tested on GHC 9.4, due to this bug on macOS 
 https://gitlab.haskell.org/ghc/ghc/-/issues/11829, which prevents C++ errors from being 
 caught when used within a Haskell binary.
 

--- a/smtlib-backends-cvc5/README.md
+++ b/smtlib-backends-cvc5/README.md
@@ -1,0 +1,21 @@
+# SMT-LIB CVC5 experimental backend
+
+__This library is currently EXPERIMENTAL__
+
+Like the `smtlib-backends-z3` package, this package uses an experimental version
+of CVC5 as a library, which allows parsing and executing SMT commands
+
+
+This Haskell library provides different low-level ways of interacting with SMT
+solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
+
+This libary is currently experimental as it requires the latest version of CVC5
+(github commit a33daf1b313f71332a00cc4556577962cc731bd2 as of writing) which exports
+a CVC5's SMTLIB parser as an API. 
+`smtlib-backends-cvc5 has also only been tested on GHC 9.4, due to this bug on macOS 
+https://gitlab.haskell.org/ghc/ghc/-/issues/11829, which prevents C++ errors from being 
+caught when used within a Haskell binary.
+
+Note that using this library will also requite using `clang++`/`g++` as linker to build 
+your final Haskell binary. See the `test-suite`'s `ghc-options` and `ld-options` in 
+`smtlib-backends-cvc5.cabal` for details.

--- a/smtlib-backends-cvc5/README.md
+++ b/smtlib-backends-cvc5/README.md
@@ -10,7 +10,7 @@ This Haskell library provides different low-level ways of interacting with SMT
 solvers using [SMT-LIB](https://smtlib.cs.uiowa.edu/).
 
 This libary is currently experimental as it requires the latest version of CVC5
-(github commit a33daf1b313f71332a00cc4556577962cc731bd2 as of writing) which exports
+(github commit 115d3d200b304e234cfd97f0eec861a620d5c998 as of writing) which exports
 a CVC5's SMTLIB parser as an API.
 
 `smtlib-backends-cvc5` has also only been tested on GHC 9.4, due to this bug on macOS 

--- a/smtlib-backends-cvc5/Setup.hs
+++ b/smtlib-backends-cvc5/Setup.hs
@@ -1,0 +1,3 @@
+import Distribution.Simple
+
+main = defaultMain

--- a/smtlib-backends-cvc5/cbits/cvc5.cpp
+++ b/smtlib-backends-cvc5/cbits/cvc5.cpp
@@ -91,7 +91,7 @@ char *cvc5_eval_smtlib2_string(cvc5_solver *slv, cvc5_parser *parser, char const
   {
     os << "(error \"" << e.getMessage() << "\")" << std::endl;
   }
-  // catch (ParserException& e)
+  // should catch (ParserException& e) here - see https://github.com/cvc5/cvc5/issues/10181
   catch (...) 
   {
     os << "(error \"unknown parser exception\")" << std::endl;

--- a/smtlib-backends-cvc5/cbits/cvc5.cpp
+++ b/smtlib-backends-cvc5/cbits/cvc5.cpp
@@ -3,6 +3,7 @@
 #include <cvc5/cvc5_parser.h>
 
 #include <iostream>
+#include <cstring>
 
 using namespace cvc5;
 using namespace cvc5::parser;

--- a/smtlib-backends-cvc5/cbits/cvc5.cpp
+++ b/smtlib-backends-cvc5/cbits/cvc5.cpp
@@ -91,10 +91,9 @@ char *cvc5_eval_smtlib2_string(cvc5_solver *slv, cvc5_parser *parser, char const
   {
     os << "(error \"" << e.getMessage() << "\")" << std::endl;
   }
-  // should catch (ParserException& e) here - see https://github.com/cvc5/cvc5/issues/10181
   catch (...) 
   {
-    os << "(error \"unknown parser exception\")" << std::endl;
+    os << "(error \"unknown solver exception\")" << std::endl;
   }
   
   auto str = os.str();

--- a/smtlib-backends-cvc5/cbits/cvc5.cpp
+++ b/smtlib-backends-cvc5/cbits/cvc5.cpp
@@ -1,0 +1,110 @@
+#include "cvc5.h"
+#include <cvc5/cvc5.h>
+#include <cvc5/cvc5_parser.h>
+
+#include <iostream>
+
+using namespace cvc5;
+using namespace cvc5::parser;
+
+
+extern "C"
+{
+
+struct cvc5_solver
+{
+    std::unique_ptr<Solver> ptr_;
+
+    cvc5_solver(Solver *slv)
+        : ptr_(slv)
+    {
+    };
+};
+
+
+struct cvc5_parser
+{
+    std::unique_ptr<InputParser> ptr_;
+
+    cvc5_parser(InputParser *parser)
+        : ptr_(parser)
+    {
+        parser->setIncrementalStringInput(modes::InputLanguage::SMT_LIB_2_6, "smtlib");
+    };
+};
+
+cvc5_solver *cvc5_solver_init()
+{
+    auto slv = new Solver();
+    return new cvc5_solver(slv);
+}
+
+void cvc5_solver_free(cvc5_solver *slv)
+{
+    delete slv;
+}
+
+cvc5_parser *cvc5_parser_init(cvc5_solver *slv)
+{
+    auto parser = new InputParser(slv->ptr_.get());
+    return new cvc5_parser(parser);
+}
+
+void cvc5_parser_free(cvc5_parser *parser)
+{
+    delete parser;
+}
+
+void cvc5_solver_set_option(cvc5_solver *slv, char const *key, char const *val)
+{
+  slv->ptr_->setOption(key, val);
+}
+
+
+char *cvc5_eval_smtlib2_string(cvc5_solver *slv, cvc5_parser *parser, char const *in_str)
+{
+  auto os = std::ostringstream{};
+
+  try
+  {
+    parser->ptr_->appendIncrementalStringInput(in_str);
+
+    // get the symbol manager of the parser, used when invoking commands below
+    SymbolManager* sm = parser->ptr_->getSymbolManager();
+
+    // parse commands until finished
+    Command cmd;
+
+    while (true)
+    {
+      cmd = parser->ptr_->nextCommand();
+      if (cmd.isNull())
+      {
+        break;
+      }
+
+      cmd.invoke(slv->ptr_.get(), sm, os);
+    }
+  }
+  catch (CVC5ApiException& e)
+  {
+    os << "(error \"" << e.getMessage() << "\")" << std::endl;
+  }
+  // catch (ParserException& e)
+  catch (...) 
+  {
+    os << "(error \"unknown parser exception\")" << std::endl;
+  }
+  
+  auto str = os.str();
+
+  // Include null terminator
+  auto total_length = str.length() + 1;
+
+  auto c_str = reinterpret_cast<char *>(malloc(total_length * sizeof(char)));
+  std::strncpy(c_str, str.c_str(), total_length);
+
+  return c_str;
+}
+
+}

--- a/smtlib-backends-cvc5/cbits/cvc5.h
+++ b/smtlib-backends-cvc5/cbits/cvc5.h
@@ -1,0 +1,38 @@
+#ifndef CVC5_H
+#define CVC5_H
+#ifndef __cplusplus
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#else
+#include <cstddef>
+#include <cstdint>
+#endif
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct cvc5_solver cvc5_solver;
+
+    typedef struct cvc5_parser cvc5_parser;
+
+    cvc5_solver *cvc5_solver_init();
+
+    void cvc5_solver_free(cvc5_solver *);
+
+    void cvc5_solver_set_option(cvc5_solver *, char const *, char const *);
+
+    cvc5_parser *cvc5_parser_init(cvc5_solver *);
+
+    void cvc5_parser_free(cvc5_parser *);
+
+    char *cvc5_eval_smtlib2_string(cvc5_solver *, cvc5_parser *, char const *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
+++ b/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
@@ -29,7 +29,9 @@ source-repository this
 
 library
   hs-source-dirs:   src
-  includes:         cbits/cvc5.h
+  include-dirs:     cbits
+  includes:
+    cvc5.h
   cxx-sources:      cbits/cvc5.cpp
   extra-libraries:
     cvc5

--- a/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
+++ b/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
@@ -9,13 +9,12 @@ description:
 license:            MIT
 license-file:       LICENSE
 author:             Sam Balco
-
 build-type:         Simple
 category:           SMT
 extra-source-files: 
-  CHANGELOG.md
   cbits/cvc5.h
   cbits/cvc5.cpp
+  CHANGELOG.md
 
 source-repository head
   type:     git
@@ -30,11 +29,12 @@ source-repository this
 
 library
   hs-source-dirs:   src
-  includes: cbits/cvc5.h
-  cxx-sources: cbits/cvc5.cpp
-  extra-libraries: 
-      cvc5
-      cvc5parser
+  includes:         cbits/cvc5.h
+  cxx-sources:      cbits/cvc5.cpp
+  extra-libraries:
+    cvc5
+    cvc5parser
+
   ghc-options:      -Wall -Wunused-packages
   exposed-modules:  SMTLIB.Backends.CVC5
   build-depends:
@@ -43,6 +43,7 @@ library
     , smtlib-backends  >=0.3     && <0.4
 
   default-language: Haskell2010
+
 test-suite test
   type:             exitcode-stdio-1.0
   hs-source-dirs:   tests
@@ -56,15 +57,18 @@ test-suite test
       base
     , bytestring
     , smtlib-backends
-    , smtlib-backends-tests
     , smtlib-backends-cvc5
+    , smtlib-backends-tests
     , tasty
     , tasty-hunit
+
   default-language: Haskell2010
 
-  if os(darwin)
+  if os(osx)
     ghc-options: -pgml clang++
+
     -- fix for https://gitlab.haskell.org/ghc/ghc/-/issues/11829
-    ld-options: -Wl,-keep_dwarf_unwind
+    ld-options:  "-Wl,-keep_dwarf_unwind"
+
   else
     ghc-options: -pgml g++

--- a/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
+++ b/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
@@ -1,0 +1,68 @@
+cabal-version:      3.0
+name:               smtlib-backends-cvc5
+version:            0.1
+synopsis:           An SMT-LIB backend implemented using CVC5's C API.
+description:
+  This library implements an SMT-LIB backend (in the sense of the smtlib-backends
+  package) using inlined calls to CVC5's C++ API.
+
+license:            MIT
+license-file:       LICENSE
+author:             Sam Balco
+
+build-type:         Simple
+category:           SMT
+extra-source-files: 
+  CHANGELOG.md
+  cbits/cvc5.h
+  cbits/cvc5.cpp
+
+source-repository head
+  type:     git
+  location: https://github.com/tweag/smtlib-backends
+  subdir:   smtlib-backends-cvc5
+
+source-repository this
+  type:     git
+  location: https://github.com/tweag/smtlib-backends
+  tag:      0.3
+  subdir:   smtlib-backends-cvc5
+
+library
+  hs-source-dirs:   src
+  includes: cbits/cvc5.h
+  cxx-sources: cbits/cvc5.cpp
+  extra-libraries: 
+      cvc5
+      cvc5parser
+  ghc-options:      -Wall -Wunused-packages
+  exposed-modules:  SMTLIB.Backends.CVC5
+  build-depends:
+      base             >=4.14    && <4.19
+    , bytestring       >=0.10.12 && <0.12
+    , smtlib-backends  >=0.3     && <0.4
+
+  default-language: Haskell2010
+test-suite test
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   tests
+  main-is:          Main.hs
+  other-modules:
+    EdgeCases
+    Examples
+
+  ghc-options:      -threaded -Wall -Wunused-packages
+  build-depends:
+      base
+    , bytestring
+    , smtlib-backends
+    , smtlib-backends-tests
+    , smtlib-backends-cvc5
+    , tasty
+    , tasty-hunit
+  default-language: Haskell2010
+
+  if os(darwin)
+    ghc-options: -pgml clang++
+    -- fix for https://gitlab.haskell.org/ghc/ghc/-/issues/11829
+    ld-options: -Wl,-keep_dwarf_unwind

--- a/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
+++ b/smtlib-backends-cvc5/smtlib-backends-cvc5.cabal
@@ -66,3 +66,5 @@ test-suite test
     ghc-options: -pgml clang++
     -- fix for https://gitlab.haskell.org/ghc/ghc/-/issues/11829
     ld-options: -Wl,-keep_dwarf_unwind
+  else
+    ghc-options: -pgml g++

--- a/smtlib-backends-cvc5/smtlib-backends-cvc5.nix
+++ b/smtlib-backends-cvc5/smtlib-backends-cvc5.nix
@@ -1,0 +1,20 @@
+## This file has been generated automatically.
+## Run `nix run .#makeBackendsDerivation` to update it.
+{ mkDerivation, base, bytestring, lib, smtlib-backends, smtlib-backends-tests, tasty
+, tasty-hunit, cvc5
+}:
+mkDerivation {
+  pname = "smtlib-backends-cvc5";
+  version = "0.1";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring smtlib-backends
+  ];
+  librarySystemDepends = [ cvc5 ];
+  testHaskellDepends = [
+    base bytestring smtlib-backends smtlib-backends-tests tasty
+    tasty-hunit
+  ];
+  description = "An SMT-LIB backend implemented using CVC5's C API";
+  license = lib.licenses.mit;
+}

--- a/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
+++ b/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
@@ -49,10 +49,9 @@ defaultConfig = Config []
 
 data Handle = Handle
   { -- | A black-box representing the internal state of the solver.
-    solver :: ForeignPtr CVC5Solver
-  , parser :: ForeignPtr CVC5Parser
+    solver :: ForeignPtr CVC5Solver,
+    parser :: ForeignPtr CVC5Parser
   }
-
 
 foreign import ccall unsafe "cvc5.h cvc5_solver_init" solver_init :: IO (Ptr CVC5Solver)
 
@@ -64,7 +63,7 @@ foreign import ccall unsafe "cvc5.h cvc5_parser_init" parser_init :: Ptr CVC5Sol
 
 foreign import ccall unsafe "cvc5.h &cvc5_parser_free" parser_free :: FunPtr (Ptr CVC5Parser -> IO ())
 
-foreign import ccall unsafe "cvc5.h cvc5_eval_smtlib2_string" eval_smtlib2_string :: Ptr CVC5Solver -> Ptr CVC5Parser ->  CString -> IO CString
+foreign import ccall unsafe "cvc5.h cvc5_eval_smtlib2_string" eval_smtlib2_string :: Ptr CVC5Solver -> Ptr CVC5Parser -> CString -> IO CString
 
 -- | Create a new solver instance.
 new :: Config -> IO Handle

--- a/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
+++ b/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A module providing a backend that sends commands to CVC5 using its C API.
+module SMTLIB.Backends.CVC5
+  ( Config (..),
+    Handle,
+    defaultConfig,
+    new,
+    close,
+    with,
+    toBackend,
+  )
+where
+
+import Control.Exception (bracket)
+import Control.Monad (forM_, void)
+import qualified Data.ByteString as BS
+import Data.ByteString.Builder.Extra
+  ( defaultChunkSize,
+    smallChunkSize,
+    toLazyByteStringWith,
+    untrimmedStrategy,
+  )
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import qualified Data.ByteString.Unsafe
+import Foreign.C.String (CString)
+import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr, withForeignPtr)
+import Foreign.Ptr (FunPtr, Ptr)
+import SMTLIB.Backends (Backend (..))
+
+data CVC5Solver
+
+data CVC5Parser
+
+newtype Config = Config
+  { -- | A list of options to set during the solver's initialization.
+    -- Each pair is of the form @(paramId, paramValue)@, e.g.
+    -- @(":produce-models", "true")@.
+    parameters :: [(BS.ByteString, BS.ByteString)]
+  }
+
+-- | By default, don't set any options during initialization.
+defaultConfig :: Config
+defaultConfig = Config []
+
+data Handle = Handle
+  { -- | A black-box representing the internal state of the solver.
+    solver :: ForeignPtr CVC5Solver
+  , parser :: ForeignPtr CVC5Parser
+  }
+
+
+foreign import ccall unsafe "cvc5.h cvc5_solver_init" solver_init :: IO (Ptr CVC5Solver)
+
+foreign import ccall unsafe "cvc5.h &cvc5_solver_free" solver_free :: FunPtr (Ptr CVC5Solver -> IO ())
+
+foreign import ccall unsafe "cvc5.h cvc5_solver_set_option" solver_set_option :: Ptr CVC5Solver -> CString -> CString -> IO ()
+
+foreign import ccall unsafe "cvc5.h cvc5_parser_init" parser_init :: Ptr CVC5Solver -> IO (Ptr CVC5Parser)
+
+foreign import ccall unsafe "cvc5.h &cvc5_parser_free" parser_free :: FunPtr (Ptr CVC5Parser -> IO ())
+
+foreign import ccall unsafe "cvc5.h cvc5_eval_smtlib2_string" eval_smtlib2_string :: Ptr CVC5Solver -> Ptr CVC5Parser ->  CString -> IO CString
+
+-- | Create a new solver instance.
+new :: Config -> IO Handle
+new config = do
+  slv' <- solver_init
+  forM_ (parameters config) $ \(paramId, paramValue) ->
+    BS.useAsCString paramId $ \cparamId ->
+      BS.useAsCString paramValue $ \cparamValue ->
+        solver_set_option slv' cparamId cparamValue
+  slv <- newForeignPtr solver_free slv'
+  prs' <- parser_init slv'
+  prs <- newForeignPtr parser_free prs'
+
+  return $ Handle slv prs
+
+-- | Release the resources associated with a CVC5 instance.
+close :: Handle -> IO ()
+close h = do
+  finalizeForeignPtr $ parser h
+  finalizeForeignPtr $ solver h
+
+-- | Create a CVC5 instance, use it to run a computation and release its resources.
+with :: Config -> (Handle -> IO a) -> IO a
+with config = bracket (new config) close
+
+-- | Create a solver backend out of a CVC5 instance.
+toBackend :: Handle -> Backend
+toBackend handle = Backend backendSend backendSend_
+  where
+    backendSend cmd = do
+      let slv = solver handle
+      let prs = parser handle
+      let cmd' =
+            LBS.toStrict $
+              toLazyByteStringWith
+                (untrimmedStrategy smallChunkSize defaultChunkSize)
+                "\NUL"
+                cmd
+      Data.ByteString.Unsafe.unsafeUseAsCString cmd' $ \ccmd' ->
+        withForeignPtr slv $ \pslv -> withForeignPtr prs $ \pprs -> do
+          resp <- eval_smtlib2_string pslv pprs ccmd'
+          LBS.fromStrict <$> BS.packCString resp
+
+    backendSend_ = void . backendSend

--- a/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
+++ b/smtlib-backends-cvc5/src/SMTLIB/Backends/CVC5.hs
@@ -53,17 +53,17 @@ data Handle = Handle
     parser :: ForeignPtr CVC5Parser
   }
 
-foreign import ccall unsafe "cvc5.h cvc5_solver_init" solver_init :: IO (Ptr CVC5Solver)
+foreign import capi unsafe "cvc5.h cvc5_solver_init" solver_init :: IO (Ptr CVC5Solver)
 
-foreign import ccall unsafe "cvc5.h &cvc5_solver_free" solver_free :: FunPtr (Ptr CVC5Solver -> IO ())
+foreign import capi unsafe "cvc5.h &cvc5_solver_free" solver_free :: FunPtr (Ptr CVC5Solver -> IO ())
 
-foreign import ccall unsafe "cvc5.h cvc5_solver_set_option" solver_set_option :: Ptr CVC5Solver -> CString -> CString -> IO ()
+foreign import capi unsafe "cvc5.h cvc5_solver_set_option" solver_set_option :: Ptr CVC5Solver -> CString -> CString -> IO ()
 
-foreign import ccall unsafe "cvc5.h cvc5_parser_init" parser_init :: Ptr CVC5Solver -> IO (Ptr CVC5Parser)
+foreign import capi unsafe "cvc5.h cvc5_parser_init" parser_init :: Ptr CVC5Solver -> IO (Ptr CVC5Parser)
 
-foreign import ccall unsafe "cvc5.h &cvc5_parser_free" parser_free :: FunPtr (Ptr CVC5Parser -> IO ())
+foreign import capi unsafe "cvc5.h &cvc5_parser_free" parser_free :: FunPtr (Ptr CVC5Parser -> IO ())
 
-foreign import ccall unsafe "cvc5.h cvc5_eval_smtlib2_string" eval_smtlib2_string :: Ptr CVC5Solver -> Ptr CVC5Parser -> CString -> IO CString
+foreign import capi unsafe "cvc5.h cvc5_eval_smtlib2_string" eval_smtlib2_string :: Ptr CVC5Solver -> Ptr CVC5Parser -> CString -> IO CString
 
 -- | Create a new solver instance.
 new :: Config -> IO Handle

--- a/smtlib-backends-cvc5/tests/EdgeCases.hs
+++ b/smtlib-backends-cvc5/tests/EdgeCases.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module EdgeCases (edgeCases) where
+
+import Data.ByteString.Builder (Builder)
+import SMTLIB.Backends as SMT
+import qualified SMTLIB.Backends.CVC5 as CVC5
+import Test.Tasty
+import Test.Tasty.HUnit
+
+edgeCases :: [TestTree]
+edgeCases =
+  [ testCase "Sending an empty command" emptyCommand,
+    testCase "Sending a command expecting no response" commandNoResponse
+  ]
+
+-- | Upon processing an empty command, the backend will respond with an empty output.
+emptyCommand :: IO ()
+emptyCommand = checkEmptyResponse ""
+
+-- | Upon processing a command producing no output, the backend will respond
+-- with an empty output.
+commandNoResponse :: IO ()
+commandNoResponse = checkEmptyResponse "(set-option :print-success false)"
+
+checkEmptyResponse :: Builder -> IO ()
+checkEmptyResponse cmd = CVC5.with CVC5.defaultConfig $ \handle -> do
+  let backend = CVC5.toBackend handle
+  response <- SMT.send backend cmd
+  assertEqual "expected no response" "" response

--- a/smtlib-backends-cvc5/tests/Examples.hs
+++ b/smtlib-backends-cvc5/tests/Examples.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Examples (examples) where
+
+import SMTLIB.Backends (QueuingFlag (..), command, command_, flushQueue, initSolver)
+import qualified SMTLIB.Backends.CVC5 as CVC5
+import Test.Tasty
+import Test.Tasty.HUnit
+
+-- | The examples for the 'CVC5' backend (using CVC5 as a library).
+examples :: [TestTree]
+examples =
+  [ testCase "basic use" basicUse,
+    testCase "flushing the queue" flushing
+  ]
+
+-- | Basic use of the 'Z3' backend.
+basicUse :: IO ()
+basicUse =
+  -- 'CVC5.with' runs a computation using the 'CVC5' backend
+  -- it takes a configuration object as argument, whose use we describe in
+  -- 'settingOptions'
+  -- here we just use the default configuration, literally @'CVC5.Config' []@
+  CVC5.with CVC5.defaultConfig $ \handle -> do
+    -- first, we make the CVC5 handle into an actual backend
+    let backend = CVC5.toBackend handle
+    -- then, we create a solver out of the backend
+    -- we enable queuing (it's faster !)
+    solver <- initSolver Queuing backend
+    -- we send a basic command to the solver and ignore the response
+    -- we can write the command as a simple string because we have enabled the
+    -- OverloadedStrings pragma
+    _ <- command solver "(get-info :name)"
+    return ()
+
+
+-- | An example on how to force the content of the queue to be evaluated.
+flushing :: IO ()
+flushing = do
+  -- sometimes you want to use 'Queuing' mode but still force some commands not
+  -- producing any output to be evaluated
+  -- in that case, using 'command' would lead to your program hanging as it waits
+  -- for a response from the solver that never comes
+  -- the solution is to use the 'command_' function and then to flush the queue
+  CVC5.with CVC5.defaultConfig $ \handle -> do
+    -- this example only makes sense in queuing mode
+    solver <- initSolver Queuing $ CVC5.toBackend handle
+    -- add a command to the queue
+    command_ solver "(assert true)"
+    -- force the queue to be evaluated
+    flushQueue solver

--- a/smtlib-backends-cvc5/tests/Examples.hs
+++ b/smtlib-backends-cvc5/tests/Examples.hs
@@ -33,7 +33,6 @@ basicUse =
     _ <- command solver "(get-info :name)"
     return ()
 
-
 -- | An example on how to force the content of the queue to be evaluated.
 flushing :: IO ()
 flushing = do

--- a/smtlib-backends-cvc5/tests/Examples.hs
+++ b/smtlib-backends-cvc5/tests/Examples.hs
@@ -18,8 +18,7 @@ examples =
 basicUse :: IO ()
 basicUse =
   -- 'CVC5.with' runs a computation using the 'CVC5' backend
-  -- it takes a configuration object as argument, whose use we describe in
-  -- 'settingOptions'
+  -- it takes a configuration object as argument
   -- here we just use the default configuration, literally @'CVC5.Config' []@
   CVC5.with CVC5.defaultConfig $ \handle -> do
     -- first, we make the CVC5 handle into an actual backend

--- a/smtlib-backends-cvc5/tests/Main.hs
+++ b/smtlib-backends-cvc5/tests/Main.hs
@@ -4,8 +4,8 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import EdgeCases (edgeCases)
 import Examples (examples)
 import SMTLIB.Backends
-import SMTLIB.Backends.Tests
 import qualified SMTLIB.Backends.CVC5 as CVC5
+import SMTLIB.Backends.Tests
 import Test.Tasty
 import Test.Tasty.HUnit
 

--- a/smtlib-backends-cvc5/tests/Main.hs
+++ b/smtlib-backends-cvc5/tests/Main.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import EdgeCases (edgeCases)
+import Examples (examples)
+import SMTLIB.Backends
+import SMTLIB.Backends.Tests
+import qualified SMTLIB.Backends.CVC5 as CVC5
+import Test.Tasty
+import Test.Tasty.HUnit
+
+main :: IO ()
+main = do
+  defaultMain $
+    testGroup
+      "Tests"
+      [ testBackend "Basic examples" validSources cvc5,
+        testGroup "API usage examples" examples,
+        testBackend "Error handling" failingSources cvc5,
+        testGroup "Edge cases" edgeCases
+      ]
+  where
+    cvc5 todo = CVC5.with CVC5.defaultConfig $ todo . CVC5.toBackend
+    validSources = filter (\source -> name source `notElem` ["assertions", "unsat cores"]) sources
+    failingSources =
+      [ Source "invalid command" $ \solver -> do
+          result <- command solver "this is not a valid command!!!"
+          assertBool ("Expecting error message, got: " ++ LBS.unpack result) $ "(error" `LBS.isPrefixOf` result
+      ]


### PR DESCRIPTION
I noticed that CVC5 has recently exported the parser into an API and have an example of parsing and executing SMTLIB commands: https://github.com/cvc5/cvc5/blob/main/examples/api/cpp/parser.cpp

I've implemented an initial version of `smtlib-backends-cvc5` to use this API, however, there are a few caveats:

* uses an unstable version of cvc5, hopefully the next release will include the new API
* due to this bug on macOS https://gitlab.haskell.org/ghc/ghc/-/issues/11829, I've upgraded the nix shell to ghc 9.4.8 as I couldn't get the suggested fix work for the version of ghc in the current shell
* The `ParserException` type doesn't seem to be exported in the parser API, so parsing errors are caught by a default `catch (...)` block, potentially giving sub-optimal error messages
* The tests and likely any downstream executables have to be linked with clang++/g++. Not sure if this is likely to cause any issues?