### PR TITLE
Documentation improvements and cleanup in initSolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The same stands for the changelogs of
 [smtlib-backends-z3](smtlib-backends-z3/CHANGELOG.md), except the version
 numbers simply follow that of `smtlib-backends`.
 
+## Next
+
+### Changed
+
+- **(breaking change)** stop changing the default of the `produce-models` option.
+
 ## v0.3 _(2023-02-03)_
 
 ### Added

--- a/src/SMTLIB/Backends.hs
+++ b/src/SMTLIB/Backends.hs
@@ -112,7 +112,6 @@ initSolver queuing solverBackend = do
       -- alternatively, we may consider that the user wanting both features should
       -- implement their own backend that deals with this
       setOption solver "print-success" "true"
-  setOption solver "produce-models" "true"
   return solver
 
 -- | Have the solver evaluate a SMT-LIB command.

--- a/src/SMTLIB/Backends.hs
+++ b/src/SMTLIB/Backends.hs
@@ -118,7 +118,12 @@ initSolver queuing solverBackend = do
 -- | Have the solver evaluate a SMT-LIB command.
 -- This forces the queued commands to be evaluated as well, but their results are
 -- *not* checked for correctness.
--- For a fixed backend, this function is *not* thread-safe.
+--
+-- Concurrent calls to different solvers are thread-safe, but not concurrent
+-- calls on the same solver or the same backend.
+--
+-- Only one command must be given per invocation, or the multiple commands must
+-- together produce the output of one command only.
 command :: Solver -> Builder -> IO LBS.ByteString
 command solver cmd = do
   send (backend solver)
@@ -130,8 +135,13 @@ command solver cmd = do
 -- In 'NoQueuing' mode, the result is checked for correctness. In 'Queuing'
 -- mode, (unless the queue is flushed and evaluated right after) the command
 -- must not produce any output when evaluated, and its output is thus in
--- particular not checked for correctness. For a fixed backend, this function is
--- *not* thread-safe.
+-- particular not checked for correctness.
+--
+-- Concurrent calls to different solvers are thread-safe, but not concurrent
+-- calls on the same solver or the same backend.
+--
+-- Only one command must be given per invocation, or the multiple commands must
+-- together produce the output of one command only.
 command_ :: Solver -> Builder -> IO ()
 command_ solver cmd =
   case queue solver of


### PR DESCRIPTION
Besides documentation and a trivial refactoring, this has `initSolver` not set `produce-models` as changing defaults can be surprising to users.

We still set `print-success` on `initSolver`, but perhaps that incurs no performance overhead, is easily discovered, and helps with debugging.